### PR TITLE
Add backwards compatibility for eradius version < 0.6 for remote calling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ eradius
 
 A generic RADIUS client and server.
 
+Version 0.6.2 - 23 Apr 2015
+---------------------------
+* add backwards compatibility with old eradius versions
+
 Version 0.6.1 - 05 Mar 2015
 ---------------------------
 * switching to lager logging


### PR DESCRIPTION
As the request was decoded on client side before, it is a compatibility layer, which check and save the version of remote eradius and use it on decision to encode request before send it remote or not. 