### PR TITLE
Add possibility to proxy radius requests

### DIFF
--- a/src/eradius_client.erl
+++ b/src/eradius_client.erl
@@ -31,6 +31,8 @@
 -type nas_address() :: {inet:ip_address(), eradius_server:port_number(), eradius_lib:secret()}.
 -type options() :: [{retries, pos_integer()} | {timeout, timeout()}].
 
+-export_type([nas_address/0]).
+
 %% ------------------------------------------------------------------------------------------
 %% -- API
 % @private

--- a/src/eradius_config.erl
+++ b/src/eradius_config.erl
@@ -58,6 +58,7 @@ validate_behavior({Nas, Args}) ->
 validate_behavior({{invalid, _} = Invalid, _Nas, _Args}) ->
     Invalid;
 validate_behavior({Module, Nas, _Args} = Value) when is_atom(Module) andalso ?is_io(Nas) ->
+    code:is_loaded(Module) =:= false andalso code:load_file(Module),
     case erlang:function_exported(Module, validate_arguments, 1) of
         true -> validate_arguments(Value);
         false -> Value

--- a/src/eradius_proxy.erl
+++ b/src/eradius_proxy.erl
@@ -17,7 +17,7 @@ radius_request(Request, NasProp, Args) ->
 
 % @private
 send_to_server(#radius_request{reqid = ReqID} = Request, Server, Port, Secret) ->
-    case eradius_client:send_request({Server, Port, Secret}, Request) of
+    case eradius_client:send_request({Server, Port, Secret}, Request, [{retries, 1}]) of
         {ok, Result, Auth} -> decode_request(Result, ReqID, Secret, Auth);
         Error -> 
             lager:error("~p: error during send_request (~p)", [?MODULE, Error]), 

--- a/src/eradius_proxy.erl
+++ b/src/eradius_proxy.erl
@@ -1,0 +1,35 @@
+-module(eradius_proxy).
+
+-behaviour(eradius_server).
+-export([radius_request/3]).
+
+-include("eradius_lib.hrl").
+
+radius_request(Request, NasProp, Args) ->
+    Secret = proplists:get_value(secret, Args, NasProp#nas_prop.secret),
+    case proplists:get_value(to, Args) of
+        undefined -> 
+            lager:error("~p: invalid configuration ('to' is not set)", [?MODULE]), 
+            bad_configuration;
+        {Ip, Port} -> send_to_server(Request, Ip, Port, Secret);
+        Ip -> send_to_server(Request, Ip, 1812, Secret)
+    end.
+
+% @private
+send_to_server(#radius_request{reqid = ReqID} = Request, Server, Port, Secret) ->
+    case eradius_client:send_request({Server, Port, Secret}, Request) of
+        {ok, Result, Auth} -> decode_request(Result, ReqID, Secret, Auth);
+        Error -> 
+            lager:error("~p: error during send_request (~p)", [?MODULE, Error]), 
+            Error
+    end.
+
+% @private
+decode_request(Result, ReqID, Secret, Auth) ->
+    case eradius_lib:decode_request(Result, Secret, Auth) of
+        Reply = #radius_request{} ->
+            {reply, Reply#radius_request{reqid = ReqID}};
+        Error -> 
+            lager:error("~p: error during decode_request (~p)", [?MODULE, Error]), 
+            Error
+    end.

--- a/src/eradius_proxy.erl
+++ b/src/eradius_proxy.erl
@@ -4,19 +4,42 @@
 -export([radius_request/3]).
 
 -include("eradius_lib.hrl").
+-include("dictionary.hrl").
 
-radius_request(Request, NasProp, Args) ->
-    Secret = proplists:get_value(secret, Args, NasProp#nas_prop.secret),
-    case proplists:get_value(to, Args) of
-        undefined -> 
-            lager:error("~p: invalid configuration ('to' is not set)", [?MODULE]), 
+-define(DEFAULT_TYPE, realm).
+-define(DEFAULT_STRIP, false).
+-define(DEFAULT_SEPARATOR, "@").
+-define(DEFAULT_OPTIONS, [{type, ?DEFAULT_TYPE}, 
+                          {strip, ?DEFAULT_STRIP}, 
+                          {separator, ?DEFAULT_SEPARATOR}]).
+
+-type route() :: erproxyadius_client:nas_address().
+-type routes() :: [{Name :: string(), route()}].
+
+radius_request(Request, _NasProp, Args) ->
+    try handle(Request, Args)
+    catch
+        _:{bad_configuration, Type} -> 
+            lager:error("~p: invalid configuration ('~p' is invalid or isn't set)", [?MODULE, Type]), 
             bad_configuration;
-        {Ip, Port} -> send_to_server(Request, Ip, Port, Secret);
-        Ip -> send_to_server(Request, Ip, 1812, Secret)
+        _:Reason -> Reason
     end.
 
 % @private
-send_to_server(#radius_request{reqid = ReqID} = Request, Server, Port, Secret) ->
+handle(Request, Args) ->
+    DefaultRoute = proplists:get_value(default_route, Args),
+    DefaultRoute =:= undefined andalso throw({bad_configuration, default_route}),
+    Options = proplists:get_value(options, Args, ?DEFAULT_OPTIONS),
+    validate_options(Options) =:= false andalso throw({bad_configuration, options}),
+    Username = eradius_lib:get_attr(Request, ?User_Name),
+    Routes = proplists:get_value(routes, Args, []),
+    {NewUsername, Route} = resolve_routes(Username, DefaultRoute, Routes, Options),
+    send_to_server(new_request(Request, Username, NewUsername), Route).
+
+% @private
+-spec send_to_server(Request :: #radius_request{}, Route :: route()) -> 
+    {reply, Reply :: #radius_request{}} | term().
+send_to_server(#radius_request{reqid = ReqID} = Request, {Server, Port, Secret}) ->
     case eradius_client:send_request({Server, Port, Secret}, Request, [{retries, 1}]) of
         {ok, Result, Auth} -> decode_request(Result, ReqID, Secret, Auth);
         Error -> 
@@ -33,3 +56,141 @@ decode_request(Result, ReqID, Secret, Auth) ->
             lager:error("~p: error during decode_request (~p)", [?MODULE, Error]), 
             Error
     end.
+
+% @private
+-spec validate_options(Options :: [proplists:property()]) -> boolean().
+validate_options(Options) ->
+    Keys = proplists:get_keys(Options),
+    lists:all(fun(Key) -> validate_option(Key, proplists:get_value(Key, Options)) end, Keys).
+
+% @private
+-spec validate_option(Key :: atom(), Value :: term()) -> boolean().
+validate_option(type, Value) when Value =:= realm; Value =:= prefix -> true;
+validate_option(type, _Value) -> false;
+validate_option(strip, Value) when is_boolean(Value) -> true;
+validate_option(strip, _Value) -> false;
+validate_option(separator, Value) when is_list(Value) -> true;
+validate_option(_, _) -> false.
+
+
+% @private
+-spec new_request(Request :: #radius_request{}, Username :: string(), NewUsername :: string()) -> 
+    NewRequest :: #radius_request{}.
+new_request(Request, Username, Username) -> Request;
+new_request(Request, _Username, NewUsername) ->
+    eradius_lib:set_attr(eradius_lib:del_attr(Request, ?User_Name),
+                         ?User_Name, NewUsername).
+
+% @private
+-spec resolve_routes(Username :: binary(), DefaultRoute :: route(), Routes :: routes(), Options :: [proplists:property()]) -> 
+    {NewUsername :: string(), Route :: route()}.
+resolve_routes(Username, {_, _, DefaultSecret} = DefaultRoute, Routes, Options) ->
+    Type = proplists:get_value(type, Options, ?DEFAULT_TYPE),
+    Strip = proplists:get_value(strip, Options, ?DEFAULT_STRIP),
+    Separator = proplists:get_value(separator, Options, ?DEFAULT_SEPARATOR),
+    case get_key(Username, Type, Strip, Separator) of
+        {not_found, NewUsername} -> {NewUsername, DefaultRoute};
+        {Key, NewUsername} ->
+            case lists:keyfind(Key, 1, Routes) of
+                {Key, {_IP, _Port, _Secret} = Route} -> {NewUsername, Route};
+                {Key, {IP, Port}} -> {NewUsername, {IP, Port, DefaultSecret}};
+                _ -> {NewUsername, DefaultRoute}
+            end
+    end.
+
+% @private
+-spec get_key(Username :: binary() | string(), Type :: atom(), Strip :: boolean(), Separator :: list()) -> 
+    {Key :: string(), NewUsername :: string()}. 
+get_key(Username, Type, Strip, Separator) when is_binary(Username) -> 
+    get_key(binary_to_list(Username), Type, Strip, Separator);
+get_key(Username, realm, Strip, Separator) -> 
+    Realm = lists:last(string:tokens(Username, Separator)),
+    {Realm, strip(Username, realm, Strip, Separator)};
+get_key(Username, prefix, Strip, Separator) -> 
+    Prefix = hd(string:tokens(Username, Separator)),
+    {Prefix, strip(Username, prefix, Strip, Separator)};
+get_key(Username, _, _, _) -> {not_found, Username}.
+
+% @private
+-spec strip(Username :: string(), Type :: atom(), Strip :: boolean(), Separator :: list()) -> 
+    NewUsername :: string().
+strip(Username, _, false, _) -> Username;
+strip(Username, realm, true, Separator) ->
+    case string:tokens(Username, Separator) of
+        [Username] -> Username;
+        [_ | _] = List -> 
+            [_ | Tail] = lists:reverse(List),
+            string:join(lists:reverse(Tail), Separator)
+    end;
+strip(Username, prefix, true, Separator) ->
+    case string:tokens(Username, Separator) of
+        [Username] -> Username;
+        [_ | Tail] -> string:join(Tail, Separator)
+    end.
+
+
+%% ------------------------------------------------------------------------------------------
+%% -- EUnit Tests
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+resolve_routes_test() ->
+    DefaultRoute = {{127, 0, 0, 1}, 1813, <<"secret">>},
+    Prod = {{127, 0, 0, 1}, 1812, <<"prod">>},
+    Test = {{127, 0, 0, 1}, 11813, <<"test">>},
+    Routes = [{"prod", Prod}, {"test", Test}],
+    % default
+    ?assertEqual({"user", DefaultRoute}, resolve_routes(<<"user">>, DefaultRoute, Routes, [])),
+    ?assertEqual({"user@prod", Prod}, resolve_routes(<<"user@prod">>, DefaultRoute, Routes, [])),
+    ?assertEqual({"user@test", Test}, resolve_routes(<<"user@test">>, DefaultRoute, Routes, [])), 
+    % strip
+    Opts = [{strip, true}],
+    ?assertEqual({"user", DefaultRoute}, resolve_routes(<<"user">>, DefaultRoute, Routes, Opts)),
+    ?assertEqual({"user", Prod}, resolve_routes(<<"user@prod">>, DefaultRoute, Routes, Opts)),
+    ?assertEqual({"user", Test}, resolve_routes(<<"user@test">>, DefaultRoute, Routes, Opts)), 
+    % prefix
+    Opts1 = [{type, prefix}, {separator, "/"}],
+    ?assertEqual({"user/example", DefaultRoute}, resolve_routes(<<"user/example">>, DefaultRoute, Routes, Opts1)),
+    ?assertEqual({"test/user", Test}, resolve_routes(<<"test/user">>, DefaultRoute, Routes, Opts1)), 
+    % prefix and strip
+    Opts2 = Opts ++ Opts1,
+    ?assertEqual({"example", DefaultRoute}, resolve_routes(<<"user/example">>, DefaultRoute, Routes, Opts2)),
+    ?assertEqual({"user", Test}, resolve_routes(<<"test/user">>, DefaultRoute, Routes, Opts2)), 
+    ok.
+
+validate_options_test() ->
+    ?assertEqual(true, validate_options(?DEFAULT_OPTIONS)),
+    ?assertEqual(true, validate_options([{type, prefix}, {separator, "/"}, {strip, true}])),
+    ?assertEqual(false, validate_options([{type, unknow}])),
+    ?assertEqual(false, validate_options([strip, abc])),
+    ?assertEqual(false, validate_options([abc, abc])),
+    ok.
+
+new_request_test() ->
+    Req0 = #radius_request{},
+    Req1 = eradius_lib:set_attr(Req0, ?User_Name, "user1"),
+    ?assertEqual(Req0, new_request(Req0, "user", "user")),
+    ?assertEqual(Req1, new_request(Req0, "user", "user1")),
+    ok.
+
+get_key_test() ->
+    ?assertEqual({"example", "user@example"}, get_key("user@example", realm, false, "@")),
+    ?assertEqual({"user", "user/domain@example"}, get_key("user/domain@example", prefix, false, "/")),
+    ?assertEqual({"example", "user"}, get_key("user@example", realm, true, "@")),
+    ?assertEqual({"example", "user@domain"}, get_key("user@domain@example", realm, true, "@")),
+    ?assertEqual({"user", "domain@example"}, get_key("user/domain@example", prefix, true, "/")),
+    ?assertEqual({"user", "domain/domain2@example"}, get_key("user/domain/domain2@example", prefix, true, "/")),
+    ok.
+
+
+strip_test() ->
+    ?assertEqual("user", strip("user", realm, false, "@")),
+    ?assertEqual("user", strip("user", prefix, false, "@")),
+    ?assertEqual("user", strip("user", realm, true, "@")),
+    ?assertEqual("user", strip("user", prefix, true, "@")),
+    ?assertEqual("user", strip("user@example", realm, true, "@")),
+    ?assertEqual("user2@example", strip("user/user2@example", prefix, true, "/")),
+    ?assertEqual("user/user2", strip("user/user2@example", realm, true, "@")),
+    ok.
+
+-endif.

--- a/test/eradius_logtest.erl
+++ b/test/eradius_logtest.erl
@@ -1,6 +1,6 @@
 -module(eradius_logtest).
 
--export([start/0, radius_request/3, test_client/0, test_client/1, validate_arguments/1]).
+-export([start/0, test/0, radius_request/3, validate_arguments/1, test_client/0, test_client/1, test_proxy/0, test_proxy/1]).
 -import(eradius_lib, [get_attr/2]).
 
 -include_lib("eradius/include/eradius_lib.hrl").
@@ -8,26 +8,43 @@
 -include_lib("eradius/include/dictionary.hrl").
 -include_lib("eradius/include/dictionary_3gpp.hrl").
 
--define(ALLOWD_USERS, [<<"test">>]).
+-define(ALLOWD_USERS, [<<"test">>, <<"proxy_test">>]).
 -define(SECRET, <<"secret">>).
+-define(SECRET2, <<"secret2">>).
 
 start() ->
     application:load(eradius),
-    Config = [{radius_callback, eradius_logtest},
-              {servers, [{root, {"127.0.0.1", [1812, 1813]}}]},
+    ProxyConfig = [{to, {{127, 0, 0, 1}, 1813}}, {secret, ?SECRET}],
+    Config = [{radius_callback, eradius_proxy},
+              {servers, [{root,  {"127.0.0.1", [1812, 1813]}},
+                         {proxy, {"127.0.0.1", [11812, 11813]}}
+                        ]},
               {session_nodes, [node()]},
               {root,
                       [
-                       { {"test", [] }, [{"127.0.0.1", ?SECRET}] }
+                       { {eradius_logtest, "test", [] }, [{"127.0.0.1", ?SECRET}] }
+                      ]
+              },
+              {proxy,
+                      [
+                       { {eradius_proxy, "proxy", ProxyConfig }, [{"127.0.0.1", ?SECRET2}] }
                       ]
               }
              ],
     [application:set_env(eradius, Key, Value) || {Key, Value} <- Config],
     {ok, _} = application:ensure_all_started(eradius),
     {ok, spawn(fun() ->
-                   eradius:modules_ready([?MODULE]),
+                   eradius:modules_ready([?MODULE, eradius_proxy]),
                    timer:sleep(infinity)
                end)}.
+
+test() ->
+    application:set_env(lager, handlers, [{lager_journald_backend, []}]),
+    eradius_logtest:start(),
+    eradius_logtest:test_client(),
+    eradius_logtest:test_proxy(),
+    ok.
+
 
 radius_request(#radius_request{cmd = request} = Request, _NasProp, _) ->
     UserName = get_attr(Request, ?User_Name),
@@ -49,21 +66,34 @@ test_client() ->
 
 test_client(Command) ->
     eradius_dict:load_tables([dictionary, dictionary_3gpp]),
-    Request = eradius_lib:set_attributes(#radius_request{cmd = Command, msg_hmac = true},[
-                {?NAS_Port, 8888},
-                {?User_Name, "test"},
-                {?NAS_IP_Address, {88,88,88,88}},
-                {?Calling_Station_Id, "0123456789"},
-                {?Service_Type, 2},
-                {?Framed_Protocol, 7},
-                {30,"some.id.com"},               %Called-Station-Id
-                {61,18},                                %NAS_PORT_TYPE
-                {{10415,1}, "1337"},                    %X_3GPP-IMSI
-                {{127,42},18}                           %Unbekannte ID
-                ] ),
-    case eradius_client:send_request({{127, 0, 0, 1}, 1813, ?SECRET}, Request) of
+    Request = eradius_lib:set_attributes(#radius_request{cmd = Command, msg_hmac = true}, attrs("test")),
+    send_request({127, 0, 0, 1}, 1813, ?SECRET, Request).
+
+test_proxy() ->
+  test_proxy(request).
+
+test_proxy(Command) ->
+    eradius_dict:load_tables([dictionary, dictionary_3gpp]),
+    Request = eradius_lib:set_attributes(#radius_request{cmd = Command, msg_hmac = true}, attrs("proxy_test")),
+    send_request({127, 0, 0, 1}, 11813, ?SECRET2, Request).
+
+send_request(Ip, Port, Secret, Request) -> 
+    case eradius_client:send_request({Ip, Port, Secret}, Request) of
         {ok, Result, Auth} ->
-            eradius_lib:decode_request(Result, ?SECRET, Auth);
+            eradius_lib:decode_request(Result, Secret, Auth);
         Error ->
             Error
     end.
+
+attrs(User) ->
+    [{?NAS_Port, 8888},
+     {?User_Name, User},
+     {?NAS_IP_Address, {88,88,88,88}},
+     {?Calling_Station_Id, "0123456789"},
+     {?Service_Type, 2},
+     {?Framed_Protocol, 7},
+     {30,"some.id.com"},                  %Called-Station-Id
+     {61,18},                             %NAS_PORT_TYPE
+     {{10415,1}, "1337"},                 %X_3GPP-IMSI
+     {{127,42},18}                        %Unbekannte ID
+    ].

--- a/test/readme.md
+++ b/test/readme.md
@@ -18,8 +18,8 @@ Start an Erlangshell
 
     `>application:set_env(lager, handlers, [{lager_journald_backend, []}]).
      >eradius_logtest:start().
-     >eradius_logtest:client_test().
-     >eradius_logtest:proxy_test().`
+     >eradius_logtest:test_client().
+     >eradius_logtest:test_proxy().`
 
 or
 

--- a/test/readme.md
+++ b/test/readme.md
@@ -18,7 +18,13 @@ Start an Erlangshell
 
     `>application:set_env(lager, handlers, [{lager_journald_backend, []}]).
      >eradius_logtest:start().
-     >eradius_logtest:client_test().`
+     >eradius_logtest:client_test().
+     >eradius_logtest:proxy_test().`
+
+or
+
+    `>eradius_logtest:test().`
+
 
 You now should find something simmilar to the following message in your journal:
 


### PR DESCRIPTION
For #16.
Proxy is radius handler. You can configure it via handler args, for example:
```erlang
ProxyConfig = [{default_route, {{127, 0, 0, 1}, 1813, <<"default_secret">>}}, 
               {options, [{type, realm}, {strip, true}, {separator, "@"}]},
               {routes, [{"test", {{127, 0, 0, 1}, 1815, <<"secret">>}}]}
              ],
....
{proxy, [
  { {eradius_proxy, "proxy", ProxyConfig }, [{"127.0.0.1", <<"proxy_secret">>}] }
]}
```

`default_route` - ip, port and secret for home server, `routes` - list of servers for routing. `options` - how to resolve route