### PR TITLE
Add IP ranges for NAS clients

### DIFF
--- a/src/eradius_server.erl
+++ b/src/eradius_server.erl
@@ -78,6 +78,7 @@ behaviour_info(callbacks) -> [{radius_request,3}].
 -spec start_link(inet:ip4_address(), port_number()) -> {ok, pid()} | {error, term()}.
 start_link(IP = {A,B,C,D}, Port) ->
     Name = list_to_atom(lists:flatten(io_lib:format("eradius_server_~b.~b.~b.~b:~b", [A,B,C,D,Port]))),
+    io:format("Name: ~p", [Name]),
     gen_server:start_link({local, Name}, ?MODULE, {IP, Port}, []).
 
 stats(Server, Function) ->

--- a/test/eradius_logtest.erl
+++ b/test/eradius_logtest.erl
@@ -27,7 +27,7 @@ start() ->
                         ]},
               {session_nodes, [node()]},
               {root, [
-                       { {eradius_logtest, "root", [] }, [{"127.0.0.1", ?SECRET}] }
+                       { {eradius_logtest, "root", [] }, [{"127.0.0.1/24", ?SECRET}] }
               ]},
               {test, [
                        { {eradius_logtest, "test", [] }, [{"127.0.0.1", ?SECRET3}] }


### PR DESCRIPTION
Relate to #23 

You can use ip ranges in this format `x.x.x.x/m`, for example:
```erlang
{root, [
    { {handler, "NAS", []}, [ {"10.18.14.2/30", <<"secret2">>, [{group, "NodeGroup"}]} ] }
]}]
```