### PR TITLE
added request-type and -id to request logging

### DIFF
--- a/src/eradius_log.erl
+++ b/src/eradius_log.erl
@@ -25,7 +25,7 @@
 
 %% API
 -export([start_link/0, write_request/2,
-         collect_meta/1, collect_message/2]).
+         collect_meta/2, collect_message/2]).
 -export([bin_to_hexstr/1]).
 
 %% gen_server callbacks
@@ -56,10 +56,12 @@ write_request(Sender, Request = #radius_request{}) ->
             ok
     end.
 
--spec collect_meta(#radius_request{}) -> [{term(),term()}].
-collect_meta(Request) ->
+-spec collect_meta(sender(),#radius_request{}) -> [{term(),term()}].
+collect_meta({_NASIP, _NASPort, ReqID}, Request) ->
+    Request_Type = binary_to_list(format_cmd(Request#radius_request.cmd)),
+    Request_ID = integer_to_list(ReqID),
     Attrs = Request#radius_request.attrs,
-    [collect_attr(Key, Val) || {Key, Val} <- Attrs].
+    [{request_type, Request_Type},{request_id, Request_ID}|[collect_attr(Key, Val) || {Key, Val} <- Attrs]].
 
 -spec collect_message(sender(),#radius_request{}) -> iolist().
 collect_message({NASIP, NASPort, ReqID}, Request) ->

--- a/src/eradius_server.erl
+++ b/src/eradius_server.erl
@@ -272,7 +272,7 @@ handle_request({HandlerMod, HandlerArg}, NasProp, EncRequest) ->
         Request = #radius_request{} ->
             request_inc_counter(Request#radius_request.cmd, NasProp),
             Sender = {NasProp#nas_prop.nas_ip, NasProp#nas_prop.nas_port, Request#radius_request.reqid},
-            lager:info(eradius_log:collect_meta(Request),"~s",
+            lager:info(eradius_log:collect_meta(Sender, Request),"~s",
                        [eradius_log:collect_message(Sender, Request)]),
             eradius_log:write_request(Sender, Request),
             apply_handler_mod(HandlerMod, HandlerArg, Request, NasProp);
@@ -309,7 +309,7 @@ apply_handler_mod(HandlerMod, HandlerArg, Request, NasProp) ->
 									       msg_hmac = Request#radius_request.msg_hmac or MsgHMAC or (size(EAPmsg) > 0),
 									       eap_msg = EAPmsg}),
             reply_inc_counter(ReplyCmd, NasProp),
-            lager:info(eradius_log:collect_meta(Reply),"~s",
+            lager:info(eradius_log:collect_meta(Sender, Reply),"~s",
                        [eradius_log:collect_message(Sender, Reply)]),
             eradius_log:write_request(Sender, Reply),
             {reply, EncReply};


### PR DESCRIPTION
the meta fields didn't contain the request-type and request-id, making it unnecessary complicated to filter for these information