### PR TITLE
properly initialize the authenticator

### DIFF
--- a/src/eradius_client.erl
+++ b/src/eradius_client.erl
@@ -89,7 +89,10 @@ send_remote_request(Node, {IP, Port, Secret}, Request, Options) when ?GOOD_CMD(R
 send_remote_request(_Node, _NAS, _Request, _Options) ->
     error(badarg).
 
-fill_authenticator(Req = #radius_request{cmd = accreq}) ->
+fill_authenticator(Req = #radius_request{cmd = Cmd})
+  when (Cmd == accreq) orelse
+       (Cmd == discreq) orelse
+       (Cmd == coareq) ->
     Req#radius_request{authenticator = eradius_lib:zero_authenticator()};
 fill_authenticator(Req = #radius_request{}) ->
     Req#radius_request{authenticator = eradius_lib:random_authenticator()}.

--- a/src/eradius_lib.erl
+++ b/src/eradius_lib.erl
@@ -60,7 +60,10 @@ get_attr_loop(_, [])                                     -> undefined.
 
 %% @doc Convert a RADIUS request to the wire format.
 -spec encode_request(#radius_request{}) -> binary().
-encode_request(Req = #radius_request{cmd = Cmd}) when (Cmd == accreq) orelse (Cmd == discreq) orelse (Cmd == coareq) ->
+encode_request(Req = #radius_request{cmd = Cmd})
+  when (Cmd == accreq) orelse
+       (Cmd == discreq) orelse
+       (Cmd == coareq) ->
     encode_reply_request(Req);
 encode_request(Req = #radius_request{reqid = ReqID, cmd = Command, authenticator = Authenticator, attrs = Attributes}) ->
     EncReq1 = encode_attributes(Req, Attributes),


### PR DESCRIPTION
Accounting, Disconnect and CoA Requests start with authenticator
consiting of 16 binary zeros, the encoder will use that to calculate
the correct authenticator.