### PR TITLE
eradius: add client metrics

### DIFF
--- a/include/eradius_lib.hrl
+++ b/include/eradius_lib.hrl
@@ -74,7 +74,7 @@
 
 -record(server_counter, {
           key                  :: term(),
-          upTime               :: erlang:timestamp(),
+          startTime            :: eralng:timestamp(),
           resetTime            :: erlang:timestamp(),
           invalidRequests = 0  :: non_neg_integer(),
           discardNoHandler = 0 :: non_neg_integer()

--- a/include/metrics.hrl
+++ b/include/metrics.hrl
@@ -1,0 +1,13 @@
+-define(SERVER_METRICS, [start_time, uptime, reset_time, invalid_requests, discards_no_handler]).
+
+-define(CLIENT_METRICS, [{socket_errors, counter}, {sockets_down, counter}, {access_requests, counter},
+                         {reject_requests, counter}, {accept_requests, counter}, {challenge_requests, counter},
+                         {accounting_requests, counter}, {accounting_responses, counter},
+                         {coa_requests, counter}, {coa_naks, counter}, {disconnect_requests, counter},
+                         {disconnect_acks, counter}, {disconnect_naks, counter}, {unknown_type_requests, counter},
+                         {access_retransmissions, counter}, {requests_time, histogram}, {remote_requests_time, histogram}]).
+
+-define(NAS_METRICS, [requests, dup_requests, replies, access_requests, access_accepts,
+		      access_rejects, access_challenges, account_requests, account_responses,
+		      packets_dropped, handler_failures, coa_requests, coaAcks, coaNaks,
+		      disconnect_requests, disc_naks, disc_acks, malformedRequests]).

--- a/src/eradius.app.src
+++ b/src/eradius.app.src
@@ -13,13 +13,16 @@
       {client_ip, undefined},
       {client_ports, 20},
       {resend_timeout, 30000},
-      {metrics, [requests, dupRequests, replies, accessRequests, accessAccepts,
-                 accessRejects, accessChallenges, accountRequests, accountResponses,
-                 packetsDropped, handlerFailure, coaRequests, coaAcks, coaNaks,
-                 disconnectRequests, discNaks, discAcks, malformedRequests,
-                 client_requests, client_remote_requests, client_socket_error, client_socket_dow,
-                 client_responses,
-                 server_uptime, server_reset_time, server_invalid_requests, server_discard_no_handler]}
+      %% Metrics configuration:
+      %%
+      %% The `metrics` configuration option provides the list which
+      %% may contains following atoms:
+      %%
+      %%  * nas - enables subscription on a nas metrics (count of dropped packets and etc...)
+      %%  * server - enables subscription on a server metrics (server uptime and etc..)
+      %%  * client - enables subscription on a client metrics (count of access requests and etc...)
+      %%
+      {metrics, [nas, server, client]}
     %% RADIUS server configuration:
 
     %% Note:

--- a/src/eradius.erl
+++ b/src/eradius.erl
@@ -59,14 +59,7 @@ ensure_ip(IP) ->
 
 %% @private
 start(_StartType, _StartArgs) ->
-    Result = eradius_sup:start_link(),
-    case application:get_env(eradius, enable_metrics) of
-        {ok, true} ->
-            eradius_metrics:start_subscriptions();
-        _ ->
-            ok
-    end,
-    Result.
+    eradius_sup:start_link().
 
 %% @private
 stop(_State) ->

--- a/src/eradius_client_socket.erl
+++ b/src/eradius_client_socket.erl
@@ -1,5 +1,6 @@
-
 -module(eradius_client_socket).
+
+-include("metrics.hrl").
 
 -behaviour(gen_server).
 
@@ -35,6 +36,7 @@ handle_info({SenderPid, send_request, {IP, Port}, ReqId, EncRequest},
         ok ->
             ReqKey = {IP, Port, ReqId},
             NPending = dict:store(ReqKey, SenderPid, Pending),
+            eradius_metrics:update_client_counter_metric(pending_requests, IP, Port, 1),
             {noreply, State#state{pending = NPending, counter = Counter+1}};
         {error, Reason} ->
             SenderPid ! {error, Reason},
@@ -54,6 +56,7 @@ handle_info({udp, Socket, FromIP, FromPort, EncRequest},
                     WaitingSender ! {self(), response, ReqId, EncRequest},
                     inet:setopts(Socket, [{active, once}]),
                     NPending = dict:erase({FromIP, FromPort, ReqId}, Pending),
+		    eradius_metrics:update_client_counter_metric(pending_requests, FromIP, FromPort, -1),
                     NState = State#state{pending = NPending, counter = Counter-1},
                     case {Mode, Counter-1} of
                         {inactive, 0}   -> {stop, normal, NState};
@@ -80,4 +83,3 @@ terminate(_Reason, _State) ->
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
-

--- a/src/eradius_counter.erl
+++ b/src/eradius_counter.erl
@@ -24,7 +24,7 @@
 
 %% @doc initialize a counter structure
 init_counter(Key = {_ServerIP, ServerPort}) when is_integer(ServerPort) ->
-	#server_counter{key = Key, upTime = eradius_lib:timestamp(), resetTime = eradius_lib:timestamp()};
+	#server_counter{key = Key, startTime = eradius_lib:timestamp(), resetTime = eradius_lib:timestamp()};
 init_counter(#nas_prop{server_ip = ServerIP, server_port = ServerPort, nas_ip = NasIP}) ->
     #nas_counter{key = {{ServerIP, ServerPort}, NasIP}};
 init_counter({{ServerIP, ServerPort}, NasIP})
@@ -32,7 +32,7 @@ init_counter({{ServerIP, ServerPort}, NasIP})
     #nas_counter{key = {{ServerIP, ServerPort}, NasIP}}.
 
 %% @doc reset counters
-reset_counter(#server_counter{upTime = Up}) -> #server_counter{upTime = Up, resetTime = eradius_lib:timestamp()};
+reset_counter(#server_counter{startTime = Up}) -> #server_counter{startTime = Up, resetTime = eradius_lib:timestamp()};
 reset_counter(Nas = #nas_prop{}) ->
     init_counter(Nas).
 

--- a/src/eradius_metrics.erl
+++ b/src/eradius_metrics.erl
@@ -1,30 +1,119 @@
 -module(eradius_metrics).
 
--export([subscriptions/1, start_subscriptions/0, start_subscriptions/2]).
--export([update_client_counter_metric/2, update_nas_prop_metric/3]).
+-include("metrics.hrl").
 
--define(DEFAULT_INTERVAL, 500).
--define(CLIENT_TYPES, [client_requests, client_remote_requests, client_socket_error, client_socket_dow, client_responses]).
+-export([get_metric_name/4, subscribe_client/1, addr_to_bin/2, subscribe_server/3, timestamp/0, update_uptime/1]).
+-export([update_client_counter_metric/4, update_nas_prop_metric/3, update_client_histogram_metric/4]).
 
-start_subscriptions() ->
-    Metrics = application:get_env(eradius, metrics),
-    case Metrics of
-        {ok, MetricsList} -> [start_subscriptions(Reporter, MetricsList) || {Reporter, _} <- exometer_report:list_reporters()];
-        _ -> ok
+subscribe_server(IP, Port, SubscriptionType) ->
+    {ok, EnabledMetrics} = application:get_env(eradius, metrics),
+    lists:foreach(fun({Reporter, _}) ->
+        {MetricsList, MetricType} = case SubscriptionType of
+					server -> {?SERVER_METRICS, value};
+					nas -> {?NAS_METRICS, value}
+				    end,
+
+	case lists:member(SubscriptionType, EnabledMetrics) of
+	    true ->
+		lists:foreach(fun(Metric) ->
+		    Name = server_metric_name(IP, Port, Metric, SubscriptionType),
+		    exometer_report:subscribe(Reporter, Name, MetricType, 1000, [{SubscriptionType, {from_name, 3}}], true)
+		end, MetricsList);
+	    false ->
+		ok
+	end
+    end,
+    exometer_report:list_reporters()),
+
+    % update server uptime and reset time metrics
+    case SubscriptionType of
+        server ->
+            StartTime = round(timestamp()),
+            exometer:update_or_create(eradius_metrics:get_metric_name(IP, Port, start_time, server), StartTime, gauge, []),
+            exometer:update_or_create(eradius_metrics:get_metric_name(IP, Port, reset_time, server), StartTime, gauge, []),
+            UptimeMetricName = eradius_metrics:get_metric_name(IP, Port, uptime, server),
+            exometer:new(UptimeMetricName, {function, eradius_metrics, update_uptime, [{IP, Port}], value, [counter]}),
+            lists:foreach(fun({Reporter, _}) ->
+                exometer_report:subscribe(Reporter, UptimeMetricName, value, 10000, [{uptime, {from_name, 3}}], true)
+	    end,
+	    exometer_report:list_reporters());
+        _ ->
+            ok
     end.
 
-start_subscriptions(Reporter, Metrics) ->
-    [exometer_report:subscribe(Reporter, Name, DataPoint, Time, [], true) || {Name, DataPoint, Time} <- subscriptions(Metrics)].
+server_metric_name(IP, Port, Metric, Type) ->
+    case Type of
+	server ->
+	    eradius_metrics:get_metric_name(IP, Port, Metric, Type);
+	_ ->
+	    FormatNasName = [IP, <<":">>, integer_to_binary(Port)],
+	    Key = binary_to_atom(erlang:iolist_to_binary(FormatNasName), utf8),
+	    [eradius, Type, Key, Metric]
+    end.
 
-subscriptions([]) ->
-    [];
-subscriptions(MetricsList) ->
-    AvailableMetrics = lists:filter(fun(Metric) -> lists:memeber(Metric, MetricsList) end, ?CLIENT_TYPES),
-    lists:map(fun(MetricName) -> {[eradius, MetricName], value, ?DEFAULT_INTERVAL} end, AvailableMetrics).
+subscribe_client(Name) ->
+    [client_subscriptions(Name, Reporter, ?CLIENT_METRICS) || {Reporter, _} <- exometer_report:list_reporters()].
 
-update_client_counter_metric(Metric, Value) ->
-    exometer:update_or_create([eradius, Metric], Value, counter, []).
+client_subscriptions({IP, Port}, Reporter, Metrics) ->
+    {ok, EnabledMetrics} = application:get_env(eradius, metrics),
+    case lists:memeber(client, EnabledMetrics) of
+	true ->
+	    lists:foreach(fun({Metric, MetricType}) ->
+				  DataPoint = case MetricType of
+						  counter ->   value;
+						  histogram -> mean;
+						  _ -> ok
+					      end,
+				  exometer_report:subscribe(Reporter, get_metric_name(IP, Port, Metric, client),
+							    DataPoint, 1000, [{client, {from_name, 3}}], true)
+			  end, Metrics);
+	fase ->
+	    ok
+    end.
 
+%% Helper
 update_nas_prop_metric(Metric, {nas_prop, _, Port, NAS, _, _ ,_, _} = _N, Value) ->
     Key = binary_to_atom(erlang:iolist_to_binary([NAS, <<":">>, integer_to_binary(Port)]), utf8),
-    exometer:update_or_create([eradius, Key, Metric], Value, counter, []).
+    exometer:update_or_create([eradius, nas, Key, Metric], Value, counter, []).
+
+%% Helpers for client metrics
+update_client_histogram_metric(Metric, ClientIp, Port, Value) ->
+    MetricId = get_metric_name(ClientIp, Port, Metric, client),
+    exometer:update_or_create(MetricId, Value, histogram, [{truncate, false}]).
+
+update_client_counter_metric(Metric, ClientIp, Port, Value) ->
+    MetricId = get_metric_name(ClientIp, Port, Metric, client),
+    exometer:update_or_create(MetricId, Value, counter, []).
+
+get_metric_name(IP, Port, MetricName, MetricType) ->
+    Name = addr_to_bin(IP, Port),
+    [eradius, MetricType, binary_to_atom(Name, utf8), MetricName].
+
+addr_to_bin(IP, Port) ->
+    {N1, N2, N3, N4} = IP,
+    erlang:iolist_to_binary([integer_to_binary(N1), <<".">>,
+			     integer_to_binary(N2), <<".">>,
+			     integer_to_binary(N3), <<".">>,
+			     integer_to_binary(N4), <<":">>, integer_to_binary(Port)]).
+
+update_uptime({IP, Port}) ->
+    {ok, [{value, ServerStartTime}, _]} = exometer:get_value(get_metric_name(IP, Port, start_time, server)),
+    CurrentTime = timestamp(),
+    round(CurrentTime - ServerStartTime).
+
+timestamp() ->
+    {MegaSecs, Secs, MicroSecs} = os:timestamp(),
+    Secs + (MegaSecs * 1000000) + (MicroSecs / 10000000).
+
+%% ------------------------------------------------------------------------------------------
+%% -- EUnit Tests
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+get_metric_name_test() ->
+    ?assertEqual(eradius_metrics:get_metric_name({127, 0, 0, 1}, 1813, reset_time, client),
+		 [eradius, client, '127.0.0.1:1813', reset_time]),
+    ?assertEqual(eradius_metrics:get_metric_name({127, 0, 0, 1}, 1812, reset_time, server),
+		 [eradius, server, '127.0.0.1:1812', reset_time]),
+    ok.
+-endif.

--- a/src/eradius_proxy.erl
+++ b/src/eradius_proxy.erl
@@ -9,19 +9,20 @@
 -define(DEFAULT_TYPE, realm).
 -define(DEFAULT_STRIP, false).
 -define(DEFAULT_SEPARATOR, "@").
--define(DEFAULT_OPTIONS, [{type, ?DEFAULT_TYPE}, 
-                          {strip, ?DEFAULT_STRIP}, 
+-define(DEFAULT_OPTIONS, [{type, ?DEFAULT_TYPE},
+                          {strip, ?DEFAULT_STRIP},
                           {separator, ?DEFAULT_SEPARATOR}]).
 
 -type route() :: erproxyadius_client:nas_address().
 -type routes() :: [{Name :: string(), route()}].
 
-radius_request(Request, _NasProp, Args) ->
+radius_request(Request, NasProp, Args) ->
+    #nas_prop{server_ip = ServerIP, server_port = Port} = NasProp,
     DefaultRoute = proplists:get_value(default_route, Args),
     Options = proplists:get_value(options, Args, ?DEFAULT_OPTIONS),
     Username = eradius_lib:get_attr(Request, ?User_Name),
     Routes = proplists:get_value(routes, Args, []),
-    {NewUsername, Route} = resolve_routes(Username, DefaultRoute, Routes, Options),
+    {NewUsername, Route} = resolve_routes(Username, DefaultRoute, Routes, {ServerIP, Port}, Options),
     send_to_server(new_request(Request, Username, NewUsername), Route).
 
 validate_arguments(Args) ->
@@ -33,15 +34,14 @@ validate_arguments(Args) ->
         _ -> true
     end.
 
-
 % @private
--spec send_to_server(Request :: #radius_request{}, Route :: route()) -> 
+-spec send_to_server(Request :: #radius_request{}, Route :: route()) ->
     {reply, Reply :: #radius_request{}} | term().
 send_to_server(#radius_request{reqid = ReqID} = Request, {Server, Port, Secret}) ->
     case eradius_client:send_request({Server, Port, Secret}, Request, [{retries, 1}]) of
         {ok, Result, Auth} -> decode_request(Result, ReqID, Secret, Auth);
-        Error -> 
-            lager:error("~p: error during send_request (~p)", [?MODULE, Error]), 
+        Error ->
+            lager:error("~p: error during send_request (~p)", [?MODULE, Error]),
             Error
     end.
 
@@ -50,17 +50,17 @@ decode_request(Result, ReqID, Secret, Auth) ->
     case eradius_lib:decode_request(Result, Secret, Auth) of
         Reply = #radius_request{} ->
             {reply, Reply#radius_request{reqid = ReqID}};
-        Error -> 
-            lager:error("~p: error during decode_request (~p)", [?MODULE, Error]), 
+        Error ->
+            lager:error("~p: error during decode_request (~p)", [?MODULE, Error]),
             Error
     end.
 
 % @private
--spec validate_route({Ip :: inet:ip_address(), Port :: eradius_server:port_number(), Secret :: eradius_lib:secret()}) -> 
+-spec validate_route({Ip :: inet:ip_address(), Port :: eradius_server:port_number(), Secret :: eradius_lib:secret()}) ->
     boolean().
 validate_route({_Ip, Port, _Secret}) when not is_integer(Port); Port =< 0; Port > 65535 -> false;
 validate_route({_Ip, _Port, Secret}) when not is_list(Secret), not is_binary(Secret) -> false;
-validate_route({Ip, _Port, _Secret}) when is_list(Ip) -> 
+validate_route({Ip, _Port, _Secret}) when is_list(Ip) ->
     {Res, _} = inet_parse:address(Ip),
     Res =:= ok;
 validate_route({Ip, Port, Secret}) when is_tuple(Ip) ->
@@ -87,7 +87,7 @@ validate_option(_, _) -> false.
 
 
 % @private
--spec new_request(Request :: #radius_request{}, Username :: string(), NewUsername :: string()) -> 
+-spec new_request(Request :: #radius_request{}, Username :: string(), NewUsername :: string()) ->
     NewRequest :: #radius_request{}.
 new_request(Request, Username, Username) -> Request;
 new_request(Request, _Username, NewUsername) ->
@@ -95,16 +95,18 @@ new_request(Request, _Username, NewUsername) ->
                          ?User_Name, NewUsername).
 
 % @private
--spec resolve_routes(Username :: undefined | binary(), DefaultRoute :: route(), Routes :: routes(), Options :: [proplists:property()]) -> 
-    {NewUsername :: string(), Route :: route()}.
-resolve_routes(undefined, {_, _, _DefaultSecret} = DefaultRoute, _Routes, _Options) ->
+-spec resolve_routes(Username :: undefined | binary(), DefaultRoute :: route(), Routes :: routes(),
+		     NasIpPort :: {inet:ip_address(), integer()}, Options :: [proplists:property()]) ->
+                     {NewUsername :: string(), Route :: route()}.
+resolve_routes( undefined, {_, _, _DefaultSecret} = DefaultRoute, _Routes, Nas, _Options) ->
     {undefined, DefaultRoute};
-resolve_routes(Username, {_, _, DefaultSecret} = DefaultRoute, Routes, Options) ->
+resolve_routes(Username, {_, _, DefaultSecret} = DefaultRoute, Routes, Nas, Options) ->
     Type = proplists:get_value(type, Options, ?DEFAULT_TYPE),
     Strip = proplists:get_value(strip, Options, ?DEFAULT_STRIP),
     Separator = proplists:get_value(separator, Options, ?DEFAULT_SEPARATOR),
     case get_key(Username, Type, Strip, Separator) of
-        {not_found, NewUsername} -> {NewUsername, DefaultRoute};
+        {not_found, NewUsername} ->
+	    {NewUsername, DefaultRoute};
         {Key, NewUsername} ->
             case lists:keyfind(Key, 1, Routes) of
                 {Key, {_IP, _Port, _Secret} = Route} -> {NewUsername, Route};
@@ -114,26 +116,26 @@ resolve_routes(Username, {_, _, DefaultSecret} = DefaultRoute, Routes, Options) 
     end.
 
 % @private
--spec get_key(Username :: binary() | string(), Type :: atom(), Strip :: boolean(), Separator :: list()) -> 
-    {Key :: string(), NewUsername :: string()}. 
-get_key(Username, Type, Strip, Separator) when is_binary(Username) -> 
+-spec get_key(Username :: binary() | string(), Type :: atom(), Strip :: boolean(), Separator :: list()) ->
+    {Key :: string(), NewUsername :: string()}.
+get_key(Username, Type, Strip, Separator) when is_binary(Username) ->
     get_key(binary_to_list(Username), Type, Strip, Separator);
-get_key(Username, realm, Strip, Separator) -> 
+get_key(Username, realm, Strip, Separator) ->
     Realm = lists:last(string:tokens(Username, Separator)),
     {Realm, strip(Username, realm, Strip, Separator)};
-get_key(Username, prefix, Strip, Separator) -> 
+get_key(Username, prefix, Strip, Separator) ->
     Prefix = hd(string:tokens(Username, Separator)),
     {Prefix, strip(Username, prefix, Strip, Separator)};
 get_key(Username, _, _, _) -> {not_found, Username}.
 
 % @private
--spec strip(Username :: string(), Type :: atom(), Strip :: boolean(), Separator :: list()) -> 
+-spec strip(Username :: string(), Type :: atom(), Strip :: boolean(), Separator :: list()) ->
     NewUsername :: string().
 strip(Username, _, false, _) -> Username;
 strip(Username, realm, true, Separator) ->
     case string:tokens(Username, Separator) of
         [Username] -> Username;
-        [_ | _] = List -> 
+        [_ | _] = List ->
             [_ | Tail] = lists:reverse(List),
             string:join(lists:reverse(Tail), Separator)
     end;
@@ -143,6 +145,16 @@ strip(Username, prefix, true, Separator) ->
         [_ | Tail] -> string:join(Tail, Separator)
     end.
 
+% @TODO have no need in it right nowm but maybe we will use it later
+%update_proxy_metric(DefaultRouter, IP, Port) ->
+%    case DefaultRouter of
+%	undefined ->
+%	    MetricName = eradius_metrics:get_metric_name(IP, Port, routes_not_resolved, proxy),
+%	    exometer:update_or_create(MetricName, 1, spiral, [{time_span, 1000}]);
+%	_ ->
+%	    MetricName = eradius_metrics:get_metric_name(IP, Port, routes_resolved, proxy),
+%	    exometer:update_or_create(MetricName, 1, spiral, [{time_span, 1000}])
+%    end.
 
 %% ------------------------------------------------------------------------------------------
 %% -- EUnit Tests
@@ -155,32 +167,34 @@ resolve_routes_test() ->
     Test = {{127, 0, 0, 1}, 11813, <<"test">>},
     Routes = [{"prod", Prod}, {"test", Test}],
     % default
-    ?assertEqual({undefined, DefaultRoute}, resolve_routes(undefined, DefaultRoute, Routes, [])),
-    ?assertEqual({"user", DefaultRoute}, resolve_routes(<<"user">>, DefaultRoute, Routes, [])),
-    ?assertEqual({"user@prod", Prod}, resolve_routes(<<"user@prod">>, DefaultRoute, Routes, [])),
-    ?assertEqual({"user@test", Test}, resolve_routes(<<"user@test">>, DefaultRoute, Routes, [])), 
+    ?assertEqual({undefined, DefaultRoute}, resolve_routes(undefined, DefaultRoute, Routes, {{127, 0, 0, 1}, 1813}, [])),
+    ?assertEqual({"user", DefaultRoute}, resolve_routes(<<"user">>, DefaultRoute, Routes, {{127, 0, 0, 1}, 1813}, [])),
+    ?assertEqual({"user@prod", Prod}, resolve_routes(<<"user@prod">>, DefaultRoute, Routes, {{127, 0, 0, 1}, 1813}, [])),
+    ?assertEqual({"user@test", Test}, resolve_routes(<<"user@test">>, DefaultRoute, Routes, {{127, 0, 0, 1}, 1813}, [])),
     % strip
     Opts = [{strip, true}],
-    ?assertEqual({"user", DefaultRoute}, resolve_routes(<<"user">>, DefaultRoute, Routes, Opts)),
-    ?assertEqual({"user", Prod}, resolve_routes(<<"user@prod">>, DefaultRoute, Routes, Opts)),
-    ?assertEqual({"user", Test}, resolve_routes(<<"user@test">>, DefaultRoute, Routes, Opts)), 
+    ?assertEqual({"user", DefaultRoute}, resolve_routes(<<"user">>, DefaultRoute, Routes, {{127, 0, 0, 1}, 1813}, Opts)),
+    ?assertEqual({"user", Prod}, resolve_routes(<<"user@prod">>, DefaultRoute, Routes, {{127, 0, 0, 1}, 1813}, Opts)),
+    ?assertEqual({"user", Test}, resolve_routes(<<"user@test">>, DefaultRoute, Routes, {{127, 0, 0, 1}, 1813}, Opts)),
     % prefix
     Opts1 = [{type, prefix}, {separator, "/"}],
-    ?assertEqual({"user/example", DefaultRoute}, resolve_routes(<<"user/example">>, DefaultRoute, Routes, Opts1)),
-    ?assertEqual({"test/user", Test}, resolve_routes(<<"test/user">>, DefaultRoute, Routes, Opts1)), 
+    ?assertEqual({"user/example", DefaultRoute}, resolve_routes(<<"user/example">>, DefaultRoute, Routes,
+								{{127, 0, 0, 1}, 1813}, Opts1)),
+    ?assertEqual({"test/user", Test}, resolve_routes(<<"test/user">>, DefaultRoute, Routes, {{127, 0, 0, 1}, 1813}, Opts1)),
     % prefix and strip
     Opts2 = Opts ++ Opts1,
-    ?assertEqual({"example", DefaultRoute}, resolve_routes(<<"user/example">>, DefaultRoute, Routes, Opts2)),
-    ?assertEqual({"user", Test}, resolve_routes(<<"test/user">>, DefaultRoute, Routes, Opts2)), 
+    ?assertEqual({"example", DefaultRoute}, resolve_routes(<<"user/example">>, DefaultRoute, Routes,
+							   {{127, 0, 0, 1}, 1813}, Opts2)),
+    ?assertEqual({"user", Test}, resolve_routes(<<"test/user">>, DefaultRoute, Routes, {{127, 0, 0, 1}, 1813}, Opts2)),
     ok.
 
 validate_arguments_test() ->
-    GoodConfig = [{default_route, {{127, 0, 0, 1}, 1813, <<"secret">>}}, 
+    GoodConfig = [{default_route, {{127, 0, 0, 1}, 1813, <<"secret">>}},
                   {options, [{type, realm}, {strip, true}, {separator, "@"}]},
                   {routes, [{"test", {{127, 0, 0, 1}, 1815, <<"secret1">>}}
                            ]}
                  ],
-    BadConfig = [{default_route, {{127, 0, 0, 1}, 1813, <<"secret">>}}, 
+    BadConfig = [{default_route, {{127, 0, 0, 1}, 1813, <<"secret">>}},
                  {options, [{type, abc}]}
                  ],
     BadConfig1 = [{default_route, {{127, 0, 0, 1}, 0, <<"secret">>}}],

--- a/test/eradius_client_SUITE.erl
+++ b/test/eradius_client_SUITE.erl
@@ -146,13 +146,13 @@ send(FUN, Ports, Address) ->
 
 wanna_send(_Config) ->
     lists:map(fun(_) ->
-                        IP = random:uniform(100),
+                        IP = {random:uniform(100), random:uniform(100), random:uniform(100), random:uniform(100)},
                         Port = random:uniform(100),
                         FUN = fun() -> gen_server:call(eradius_client, {wanna_send, {IP, Port}}) end,
                         send(FUN, null, null)
                 end, lists:seq(1, 10)).
 
-%% I've catched some data races with `delSocket()' and `getSocketCount()' when 
+%% I've catched some data races with `delSocket()' and `getSocketCount()' when
 %% `delSocket()' happens after `getSocketCount()' (because `delSocket()' is sent from another process).
 %% I don't know a better decision than add some delay before `getSocketCount()'
 reconf_address(_Config) ->


### PR DESCRIPTION
This commit provides mostly two things:

First of all it provides client side metrics. We already have some client
side metrics which are were added in the 80a4204 commit (Initial support for
exometer metrics), but they represent only general metrics, like amount of
socket errors, count of client requests and etc. Besides these general metrics
we can calculate more specific metrics like count of the 'access requests',
count of the 'accept responses' and etc.

The second change that now eradius environment provides new: 'metrics' configuration
which just represents a list of metric types which are will be enabled after start.