### PR TITLE
simplify the resending logic

### DIFF
--- a/src/eradius.app.src
+++ b/src/eradius.app.src
@@ -12,7 +12,6 @@
       {tables, [dictionary]},
       {client_ip, undefined},
       {client_ports, 20},
-      {resend_timeout, 30000},
       %% Metrics configuration:
       %%
       %% The `metrics` configuration option provides the list which


### PR DESCRIPTION
 * simplify response resending because one client can send many requests from one socket with the same request ids, but they was responsed as duplicated requests