### PR TITLE
performance tuning

### DIFF
--- a/src/eradius.app.src
+++ b/src/eradius.app.src
@@ -7,11 +7,11 @@
    {mod, {eradius, []}},
    {env, [
       {servers, []},
-      {logging, true},
+      {logging, false},
       {logfile, "./radius.log"},
       {tables, [dictionary]},
       {client_ip, undefined},
-      {client_ports, 20},
+      {client_ports, 100},
       {resend_timeout, 30000},
       %% Metrics configuration:
       %%


### PR DESCRIPTION
  * make possible to disable retransmittion by setting resend_timeout to 0
  * set default retransmittion time to 2 sec (https://tools.ietf.org/html/rfc5080#section-2.2.1)
  * default disable file logging
  * set default client_ports to 100 to allow more parallel sockets in the client