### PR TITLE
define the macro name as atom

### DIFF
--- a/rebar_plugins/eradius_compile_dicts_plugin.erl
+++ b/rebar_plugins/eradius_compile_dicts_plugin.erl
@@ -97,13 +97,13 @@ mk_outfiles(Res, Dir, File) ->
 %%     emit(T, Hrl, Map);
 
 emit([A|T], Hrl, Map) when is_record(A, attribute) ->
-    io:format(Hrl, "-define( ~s , ~w ).~n",
+    io:format(Hrl, "-define( '~s' , ~w ).~n",
         [d2u(A#attribute.name), A#attribute.id]),
     io:format(Map, "~w.~n", [A]),
     emit(T, Hrl, Map);
 
 emit([V|T], Hrl, Map) when is_record(V, vendor) ->
-    io:format(Hrl, "-define( ~s , ~w ).~n",
+    io:format(Hrl, "-define( '~s' , ~w ).~n",
         [d2u(V#vendor.name), V#vendor.type]),
     io:format(Map, "~w.~n", [V]),
     emit(T, Hrl, Map);

--- a/tetrapak/eradius_compile_dicts.erl
+++ b/tetrapak/eradius_compile_dicts.erl
@@ -41,13 +41,13 @@ mk_outfiles(Res, Dir, File) ->
 %%     emit(T, Hrl, Map);
 
 emit([A|T], Hrl, Map) when is_record(A, attribute) ->
-    io:format(Hrl, "-define( ~s , ~w ).~n",
+    io:format(Hrl, "-define( '~s' , ~w ).~n",
 	      [d2u(A#attribute.name), A#attribute.id]),
     io:format(Map, "~w.~n", [A]),
     emit(T, Hrl, Map);
 
 emit([V|T], Hrl, Map) when is_record(V, vendor) ->
-    io:format(Hrl, "-define( ~s , ~w ).~n",
+    io:format(Hrl, "-define( '~s' , ~w ).~n",
 	      [d2u(V#vendor.name), V#vendor.type]),
     io:format(Map, "~w.~n", [V]),
     emit(T, Hrl, Map);


### PR DESCRIPTION
  * some dictionaries have spetial attribute names like "Altiga_L2TP_Min_Authentication_G/U" in altiga that was transformed wrong