### PR TITLE
Fix eradius_client:send_remote_request_loop call in spawn

### DIFF
--- a/src/eradius_client.erl
+++ b/src/eradius_client.erl
@@ -88,8 +88,10 @@ send_remote_request(Node, {IP, Port, Secret}, Request, Options) when ?GOOD_CMD(R
                            _ ->
                                Request1
                        end,
+            Retries = proplists:get_value(retries, Options, ?DEFAULT_RETRIES),
+            Timeout = proplists:get_value(timeout, Options, ?DEFAULT_TIMEOUT),
             SenderPid = spawn(Node, ?MODULE, send_remote_request_loop,
-                             [self(), Socket, ReqId, Peer, Request2, Options]),
+                             [self(), Socket, ReqId, Peer, Request2, Retries, Timeout, MetricsInfo]),
             SenderMonitor = monitor(process, SenderPid),
             Value = receive
                        {SenderPid, Result} ->


### PR DESCRIPTION
Because it is a `\8` function and not `\6` as before