### PR TITLE
Dialyzer client and proxy fixes

### DIFF
--- a/src/eradius_client.erl
+++ b/src/eradius_client.erl
@@ -49,7 +49,8 @@ send_request(NAS, Request) ->
 
 % @doc Send a radius request to the given NAS.
 %   If no answer is received within the specified timeout, the request will be sent again.
--spec send_request(nas_address(), #radius_request{}, options()) -> {ok, binary()} | {error, 'timeout' | 'socket_down'}.
+-spec send_request(nas_address(), #radius_request{}, options()) -> 
+    {ok, binary(), eradius_lib:authenticator()} | {error, 'timeout' | 'socket_down'}.
 send_request({IP, Port, Secret}, Request, Options) when ?GOOD_CMD(Request) andalso is_tuple(IP) ->
     TS1 = eradius_metrics:timestamp(milli_seconds),
     ServerName = proplists:get_value(server_name, Options, undefined),
@@ -106,8 +107,6 @@ send_remote_request(Node, {IP, Port, Secret}, Request, Options) when ?GOOD_CMD(R
 send_remote_request(_Node, {_IP, _Port, _Secret}, _Request, _Options) ->
     error(badarg).
 
-proceed_response(Request, Value, Peer, TS1, undefined) ->
-    proceed_response(Request, Value, Peer, TS1, eradius_metrics:make_addr_info(Peer));
 proceed_response(Request, Value, _Peer, TS1, MetricsInfo) ->
     TS2 = eradius_metrics:timestamp(milli_seconds),
     case Value of
@@ -204,7 +203,7 @@ reconfigure() ->
 %% ------------------------------------------------------------------------------------------
 %% -- socket process manager
 -record(state, {
-    socket_ip :: inet:ip_address(),
+    socket_ip :: null | inet:ip_address(),
     no_ports = 1 :: pos_integer(),
     idcounters = dict:new() :: dict:dict(),
     sockets = array:new() :: array:array(),

--- a/src/eradius_proxy.erl
+++ b/src/eradius_proxy.erl
@@ -55,7 +55,7 @@ decode_request(Result, ReqID, Secret, Auth) ->
     end.
 
 % @private
--spec validate_route({Ip :: inet:ip_address(), Port :: eradius_server:port_number(), Secret :: eradius_lib:secret()}) ->
+-spec validate_route({Ip :: list() | inet:ip_address(), Port :: eradius_server:port_number(), Secret :: eradius_lib:secret()}) ->
     boolean().
 validate_route({_Ip, Port, _Secret}) when not is_integer(Port); Port =< 0; Port > 65535 -> false;
 validate_route({_Ip, _Port, Secret}) when not is_list(Secret), not is_binary(Secret) -> false;
@@ -86,7 +86,9 @@ validate_option(_, _) -> false.
 
 
 % @private
--spec new_request(Request :: #radius_request{}, Username :: string(), NewUsername :: string()) ->
+-spec new_request(Request :: #radius_request{}, 
+                  Username :: undefined | binary(), 
+                  NewUsername :: string()) ->
     NewRequest :: #radius_request{}.
 new_request(Request, Username, Username) -> Request;
 new_request(Request, _Username, NewUsername) ->
@@ -105,7 +107,7 @@ resolve_routes(Username, {_, _, DefaultSecret} = DefaultRoute, Routes, Options) 
     Separator = proplists:get_value(separator, Options, ?DEFAULT_SEPARATOR),
     case get_key(Username, Type, Strip, Separator) of
         {not_found, NewUsername} ->
-	    {NewUsername, DefaultRoute};
+            {NewUsername, DefaultRoute};
         {Key, NewUsername} ->
             case lists:keyfind(Key, 1, Routes) of
                 {Key, {_IP, _Port, _Secret} = Route} -> {NewUsername, Route};
@@ -116,7 +118,7 @@ resolve_routes(Username, {_, _, DefaultSecret} = DefaultRoute, Routes, Options) 
 
 % @private
 -spec get_key(Username :: binary() | string(), Type :: atom(), Strip :: boolean(), Separator :: list()) ->
-    {Key :: string(), NewUsername :: string()}.
+    {Key :: not_found | string(), NewUsername :: string()}.
 get_key(Username, Type, Strip, Separator) when is_binary(Username) ->
     get_key(binary_to_list(Username), Type, Strip, Separator);
 get_key(Username, realm, Strip, Separator) ->


### PR DESCRIPTION
I was experimenting with dialyzer and found some "error" in specs. 
The scope of changes:

client:
* Fix spec for `send_request/3`. In success it alway returns `{ok, binary(), eradius_lib:authenticator()}`.
* Remove `proceed_response(Request, Value, Peer, TS1, undefined)`. Because `MetricsInfo` can't be `undefined`.
* Use `null` as possible type for socket_ip. Because `null` is incorrect value for `inet:ip_address()`

proxy:
* Fix spec for `validate_route/1`
* Fix spec for `new_request/3`.Username should be `undefined` or `binary()`
* Fix spec for `get_key/4`. It may return `not_found`.