### PR TITLE
replace all dots (.) in dictionaries with underscores (_)

### DIFF
--- a/rebar_plugins/eradius_compile_dicts_plugin.erl
+++ b/rebar_plugins/eradius_compile_dicts_plugin.erl
@@ -32,7 +32,7 @@ clean(Config, Appfile) ->
 out_files(_Config, DictionaryFile) ->
     {ok, Basedir} = file:get_cwd(),
     DictionaryFileBase = filename:basename(DictionaryFile),
-    OutfileBase = re:replace(DictionaryFileBase, "\\.", "_", [{return, list}]),
+    OutfileBase = re:replace(DictionaryFileBase, "\\.", "_", [global, {return, list}]),
     Headerfile = string:join([OutfileBase, "hrl"], "."),
     HeaderfileFQ = filename:join([Basedir, "include", Headerfile]),
     Mapfile = string:join([OutfileBase, "map"], "."),


### PR DESCRIPTION
The alcatel.sr dictionary contains two dots. Without the
global option to re:replace, only the first dot is replaced.

Fixes #77 