### PR TITLE
Use hooks to compile and clean Radius dictionaries

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,8 +9,9 @@
 	{exometer_core, ".*", {git, "git://github.com/Feuerlabs/exometer_core", {branch, "master"}}}
 ]}.
 
-{plugin_dir, "rebar_plugins"}.
-{plugins, [eradius_compile_dicts_plugin]}.
+{plugins, []}.
+{pre_hooks, [{compile, "./dicts_compiler.erl compile"},
+             {clean, "./dicts_compiler.erl clean"}]}.
 
 {cover_enabled, true}.
 {cover_export_enabled, true}.

--- a/src/eradius_lib.erl
+++ b/src/eradius_lib.erl
@@ -469,7 +469,7 @@ salt_crypt(Op, SharedSecret, B, <<PlainText:16/binary, Remaining/binary>>, Ciphe
 	    end,
     salt_crypt(Op, SharedSecret, Bnext, Remaining, <<CipherText/binary, NewCipherText/binary>>);
 
-salt_crypt(Op, _SharedSecret, _B, << >>, CipherText) ->
+salt_crypt(_Op, _SharedSecret, _B, << >>, CipherText) ->
     CipherText.
 
 %% @doc pad binary to specific length


### PR DESCRIPTION
Previously we used rebar plugin to build Radius dictionaries but it only works with rebar2.
Using hooks allows us easy change to rebar3.