### PR TITLE
proper type for RFC 3162 IPv6 attributes

### DIFF
--- a/priv/dictionaries/dictionary
+++ b/priv/dictionaries/dictionary
@@ -166,10 +166,10 @@ ATTRIBUTE	Acct-Interim-Interval   85      integer
 ATTRIBUTE	NAS-Port-Id		87	string
 ATTRIBUTE	Framed-Pool		88	string
 ATTRIBUTE	Chargeable-User-Identity	89	string
-ATTRIBUTE	NAS-IPv6-Address	95	octets	# really IPv6
+ATTRIBUTE	NAS-IPv6-Address	95	ipv6addr
 ATTRIBUTE	Framed-Interface-Id	96	octets	# 8 octets
-ATTRIBUTE	Framed-IPv6-Prefix	97	octets	# stupid format
-ATTRIBUTE	Login-IPv6-Host		98	octets	# really IPv6
+ATTRIBUTE	Framed-IPv6-Prefix	97	ipv6prefix
+ATTRIBUTE	Login-IPv6-Host		98	ipv6addr
 ATTRIBUTE	Framed-IPv6-Route	99	string
 ATTRIBUTE	Framed-IPv6-Pool	100	string
 


### PR DESCRIPTION
The actual en/decoder functions are already there. Just fix the
type declaration in the dictionary.