### PR TITLE
Increase Erlang versions in Travis and add rebar3 env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,23 @@
 before_install:
-   - wget https://github.com/rebar/rebar/wiki/rebar
-   - chmod u+x ./rebar
+    - wget https://github.com/rebar/rebar/wiki/rebar
+    - chmod u+x ./rebar
+    - wget https://s3.amazonaws.com/rebar3/rebar3
+    - chmod u+x ./rebar3
 language: erlang
 otp_release:
-   - 17.5
-   - 18.0
-script: "./rebar compile && ./rebar skip_deps=true eunit ct send-coveralls"
-after_failure: "cat logs/raw.log"
+    - 18.3
+    - 19.0
+install: "true"
+env:
+    - BUILDTOOL=rebar
+    - BUILDTOOL=rebar3
+script:
+    - case "$BUILDTOOL" in
+        rebar) ./rebar get-deps compile && ./rebar skip_deps=true eunit ct send-coveralls;;
+        rebar3) ./rebar3 do compile, eunit && ./rebar3 ct;; 
+      esac
++after_failure:
+    - case "$BUILDTOOL" in
+        rebar) cat logs/raw/log;;
+        rebar3) echo "no raw.log on rebar3";;
+      esac

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts, [debug_info, {parse_transform, lager_transform}]}.
 
 {deps, [
-	{lager, ".*",     {git, "git://github.com/basho/lager", {tag, "2.0.3"}}},
+	{lager, ".*",     {git, "git://github.com/basho/lager", {tag, "3.2.1"}}},
 	{meck,  ".*",     {git, "git://github.com/eproxus/meck.git", {branch, "master"}}},
 	{coveralls, ".*", {git, "git://github.com/markusn/coveralls-erl.git", {branch, "master"}}},
 	{exometer_core, ".*", {git, "git://github.com/Feuerlabs/exometer_core", {branch, "master"}}}

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,10 +1,15 @@
 %% -*- erlang -*-
+code:is_loaded(rebar3) =:= false andalso code:load_file(rebar3),
+CoverallsPlugin = case erlang:function_exported(rebar3, version, 0) of
+    true -> {coveralls, {git, "git://github.com/markusn/coveralls-erl.git", {branch, "master"}}};
+    false -> rebar_coveralls
+end,
 case os:getenv("TRAVIS") of
     "true" ->
         JobId   = os:getenv("TRAVIS_JOB_ID"),
         CONFIG1 = lists:keystore(coveralls_service_job_id, 1, CONFIG, {coveralls_service_job_id, JobId}),
         {value, {plugins, Plugins}} = lists:keysearch(plugins, 1, CONFIG1),
-        lists:keystore(plugins, 1, CONFIG1, {plugins, Plugins ++ [rebar_coveralls]})
+        lists:keystore(plugins, 1, CONFIG1, {plugins, Plugins ++ [CoverallsPlugin]})
             ++ [{coveralls_coverdata, "logs/all.coverdata"},
                 {coveralls_service_name, "travis-ci"},
                 {do_coveralls_after_ct, false},


### PR DESCRIPTION
Also lager was updated to build with Erlang 19.
Note that we don't send coveralls data via rebar3 because cover.spec is
not supported now.