### PR TITLE
make maximum socket receive buffer configurable

### DIFF
--- a/src/eradius.app.src
+++ b/src/eradius.app.src
@@ -13,7 +13,8 @@
       {resend_timeout, 30000},
       {logging, false},
       {logfile, "./radius.log"},
-      {metrics, [{enabled, [server, nas, client]}]}
+      {metrics, [{enabled, [server, nas, client]}]},
+      {recbuf, 8192} % maximum socket receive buffer in bytes
 
       %% RADIUS server configuration:
       %%

--- a/src/eradius_client_socket.erl
+++ b/src/eradius_client_socket.erl
@@ -18,7 +18,8 @@ init([SocketIP, Client, PortIdx]) ->
         SocketIP when is_tuple(SocketIP) ->
             ExtraOptions = [{ip, SocketIP}]
     end,
-    {ok, Socket} = gen_udp:open(0, [{active, once}, binary | ExtraOptions]),
+    RecBuf = application:get_env(eradius, recbuf, 8192),
+    {ok, Socket} = gen_udp:open(0, [{active, once}, binary , {recbuf, RecBuf} | ExtraOptions]),
     Pending = dict:new(),
     {ok, #state{client = Client, socket = Socket, pending = Pending, mode = active, counter = 0}}.
 

--- a/src/eradius_server.erl
+++ b/src/eradius_server.erl
@@ -93,7 +93,8 @@ stats(Server, Function) ->
 %% @private
 init({ServerName, IP, Port}) ->
     process_flag(trap_exit, true),
-    case gen_udp:open(Port, [{active, once}, {ip, IP}, binary]) of
+    RecBuf = application:get_env(eradius, recbuf, 8192),
+    case gen_udp:open(Port, [{active, once}, {ip, IP}, binary, {recbuf, RecBuf}]) of
         {ok, Socket} ->
             MetricsAddress = eradius_metrics:make_addr_info({ServerName, {IP, Port}}),
             eradius_metrics:update_server_time(reset, MetricsAddress),


### PR DESCRIPTION
With high amount of udp packets if you can't process all of the receive packets,
kernel will drop new incoming packets if the socket receive buffer is full.
Using `recbuf` option it's possible to configure the socket receive buffer size.
The kernel options `net.core.rmem_max` and `net.core.netdev_max_backlog` should
also be configured.