### PR TITLE
use crypto:strong_rand_bytes/1 instead of crypto:rand_bytes/1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,7 @@
 {eunit_opts, [verbose]}.
 
 {erl_opts, [debug_info, {parse_transform, lager_transform}]}.
+{minimum_otp_vsn, "18.3"}.
 
 {deps, [
 	{lager, ".*",     {git, "git://github.com/basho/lager", {tag, "3.2.2"}}},

--- a/src/eradius_lib.erl
+++ b/src/eradius_lib.erl
@@ -27,7 +27,7 @@
 %% ------------------------------------------------------------------------------------------
 %% -- Request Accessors
 -spec random_authenticator() -> authenticator().
-random_authenticator() -> crypto:rand_bytes(16).
+random_authenticator() -> crypto:strong_rand_bytes(16).
 
 -spec zero_authenticator() -> authenticator().
 zero_authenticator() -> <<0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0>>.


### PR DESCRIPTION
as it is deprecated and will be removed.