### PR TITLE
Fix dictionary compiler to build basic dictionary first

### DIFF
--- a/dicts_compiler.erl
+++ b/dicts_compiler.erl
@@ -17,10 +17,15 @@ compile() ->
     case find_files("priv/dictionaries", "^dictionary.*") of
         [] -> 
             ok;
-        Dictionaries ->
+        Dictionaries0 ->
             {ok, Basedir} = file:get_cwd(),
             IncludeDir = filename:join([Basedir, "include"]),
             ok = filelib:ensure_dir(IncludeDir),
+            % sort dictionaries in alphabetical order to be sure that
+            % basic `priv/dictionaries/dictionary` builds first
+            % because it contains some attributes which may be needed 
+            % for vendor's dictionaries
+            Dictionaries = lists:sort(Dictionaries0),
             Targets = [{Dictionary, out_files(Dictionary)} || Dictionary <- Dictionaries],
             compile_each(Targets)
     end.

--- a/priv/dictionaries/dictionary.ascend
+++ b/priv/dictionaries/dictionary.ascend
@@ -1018,8 +1018,8 @@ VALUE	Ascend-FR-Direct		FR-Direct-Yes	1
 VALUE	Ascend-FR-Link-Mgt		Ascend-FR-No-Link-Mgt	0
 VALUE	Ascend-FR-Link-Mgt		Ascend-FR-Q-933A	2
 VALUE	Ascend-FR-Link-Mgt		Ascend-FR-T1-617D	1
-VALUE	Ascend-FR-Link-Status-Dlci		Ascend-FR-LMI-Dlci-0	0
-VALUE	Ascend-FR-Link-Status-Dlci		Ascend-FR-LMI-Dlci-1023	1023
+VALUE	Ascend-FR-Link-Status-DLCI		Ascend-FR-LMI-DLCI-0	0
+VALUE	Ascend-FR-Link-Status-DLCI		Ascend-FR-LMI-DLCI-1023	1023
 VALUE	Ascend-FR-LinkUp		Ascend-LinkUp-AlwaysUp	1
 VALUE	Ascend-FR-LinkUp		Ascend-LinkUp-Default	0
 VALUE	Ascend-FR-Type		Ascend-FR-DCE	1

--- a/priv/dictionaries/dictionary.erx
+++ b/priv/dictionaries/dictionary.erx
@@ -86,8 +86,8 @@ VALUE	ERX-Atm-Service-Category	UBRPCR			2
 VALUE	ERX-Atm-Service-Category	nrtVBR			3
 VALUE	ERX-Atm-Service-Category	CBR			4
 
-VALUE	ERX-CLI-Allow-All-VR-Access	disable			0
-VALUE	ERX-CLI-Allow-All-VR-Access	enable			1
+VALUE	ERX-Cli-Allow-All-VR-Access	disable			0
+VALUE	ERX-Cli-Allow-All-VR-Access	enable			1
 
 VALUE	ERX-Sa-Validate			disable			0
 VALUE	ERX-Sa-Validate			enable			1

--- a/priv/dictionaries/dictionary.nomadix
+++ b/priv/dictionaries/dictionary.nomadix
@@ -14,5 +14,5 @@ ATTRIBUTE       Nomadix-MaxBytesDown    8       integer         Nomadix
 ATTRIBUTE       Nomadix-EndofSession    9       integer         Nomadix
 ATTRIBUTE       Nomadix-Logoff-URL      10      string          Nomadix
 
-VALUE		Nomadix-Ip-Upsell	PrivatePool		0
-VALUE		Nomadix-Ip-Upsell	PublicPool		1
+VALUE		Nomadix-IP-Upsell	PrivatePool		0
+VALUE		Nomadix-IP-Upsell	PublicPool		1

--- a/priv/dictionaries/dictionary.redback
+++ b/priv/dictionaries/dictionary.redback
@@ -141,9 +141,9 @@ VALUE	Bind-Auth-Protocol	AAA-PPP-CHAP-WAIT-PAP		5
 VALUE	Tunnel-Function		LAC-Only			1
 VALUE	Tunnel-Function		LNS-Only			2
 VALUE	Tunnel-Function		LAC-LNS				3
-VALUE	Tunnel-Session-auth	CHAP				1
-VALUE	Tunnel-Session-auth	PAP				2
-VALUE	Tunnel-Session-auth	CHAP-PAP			3
+VALUE	Tunnel-Session-Auth	CHAP				1
+VALUE	Tunnel-Session-Auth	PAP				2
+VALUE	Tunnel-Session-Auth	CHAP-PAP			3
 VALUE	Mcast-Send		NO-SEND				1
 VALUE	Mcast-Send		SEND				2
 VALUE	Mcast-Send		UNSOLICITED-SEND		3
@@ -329,9 +329,9 @@ VALUE	Bind_Auth_Protocol	AAA_PPP_CHAP_WAIT_PAP		5
 VALUE	Tunnel_Function		LAC-Only			1
 VALUE	Tunnel_Function		LNS-Only			2
 VALUE	Tunnel_Function		LAC-LNS				3
-VALUE	Tunnel_Session_auth	CHAP				1
-VALUE	Tunnel_Session_auth	PAP				2
-VALUE	Tunnel_Session_auth	CHAP-PAP			3
+VALUE	Tunnel_Session_Auth	CHAP				1
+VALUE	Tunnel_Session_Auth	PAP				2
+VALUE	Tunnel_Session_Auth	CHAP-PAP			3
 VALUE	Mcast_Send		NO-SEND				1
 VALUE	Mcast_Send		SEND				2
 VALUE	Mcast_Send		UNSOLICITED-SEND		3


### PR DESCRIPTION
To get rid annoying compile warning like this:

    missing: "Framed-Compression"