### PR TITLE
Add TP-Trace-Id to Travelping dictionary

### DIFF
--- a/priv/dictionaries/dictionary.travelping
+++ b/priv/dictionaries/dictionary.travelping
@@ -71,6 +71,7 @@ ATTRIBUTE	TP-CAPWAP-Other-Software-Version	59	string
 ATTRIBUTE	TP-Excess-Input-Octets                  60      integer64
 ATTRIBUTE	TP-Excess-Output-Octets                 61      integer64
 ATTRIBUTE	TP-Excess-Total-Octets                  62      integer64
+ATTRIBUTE	TP-Trace-Id				63	string
 
 VALUE		TP-TLS-Auth-Type	Pre-Shared-Key           0
 VALUE		TP-TLS-Auth-Type	X509-Subject-CommonName  1


### PR DESCRIPTION
May be used to share some OpenTracing id between components.