### PR TITLE
Fix ipv6prefix coding

### DIFF
--- a/src/eradius_lib.erl
+++ b/src/eradius_lib.erl
@@ -8,6 +8,7 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+-export([encode_value/2, decode_value/2]).
 -endif.
 -include("eradius_lib.hrl").
 -include("eradius_dict.hrl").
@@ -202,8 +203,8 @@ encode_value(ipv6addr, {A,B,C,D,E,F,G,H}) ->
     <<A:16, B:16, C:16, D:16, E:16, F:16, G:16, H:16>>;
 encode_value(ipv6prefix, {{A,B,C,D,E,F,G,H}, PLen}) ->
     L = (PLen + 7) div 8,
-    <<IP:L, _R/binary>> = <<A:16, B:16, C:16, D:16, E:16, F:16, G:16, H:16>>,
-    <<0, PLen, IP>>;
+    <<IP:L/bytes, _R/binary>> = <<A:16, B:16, C:16, D:16, E:16, F:16, G:16, H:16>>,
+    <<0, PLen, IP/binary>>;
 encode_value(string, V) when is_list(V) ->
     unicode:characters_to_binary(V);
 encode_value(octets, V) when is_list(V) ->
@@ -403,7 +404,7 @@ decode_value(<<Bin/binary>>, Type) ->
             {B,C,D,E,F,G,H,I};
         ipv6prefix ->
             <<0,PLen,P/binary>> = Bin,
-            <<B:16,C:16,D:16,E:16,F:16,G:16,H:16,I:16>> = pad_to(128, P),
+            <<B:16,C:16,D:16,E:16,F:16,G:16,H:16,I:16>> = pad_to(16, P),
             {{B,C,D,E,F,G,H,I}, PLen}
     end.
 

--- a/test/eradius_lib_SUITE.erl
+++ b/test/eradius_lib_SUITE.erl
@@ -1,0 +1,58 @@
+% Copyright (c) 2010-2017 by Travelping GmbH <info@travelping.com>
+
+% Permission is hereby granted, free of charge, to any person obtaining a
+% copy of this software and associated documentation files (the "Software"),
+% to deal in the Software without restriction, including without limitation
+% the rights to use, copy, modify, merge, publish, distribute, sublicense,
+% and/or sell copies of the Software, and to permit persons to whom the
+% Software is furnished to do so, subject to the following conditions:
+
+% The above copyright notice and this permission notice shall be included in
+% all copies or substantial portions of the Software.
+
+% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+% IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+% FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+% AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+% LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+% FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+% DEALINGS IN THE SOFTWARE.
+
+-module(eradius_lib_SUITE).
+-compile(export_all).
+
+-define(equal(Expected, Actual),
+    (fun (Expected@@@, Expected@@@) -> true;
+	 (Expected@@@, Actual@@@) ->
+	     ct:pal("MISMATCH(~s:~b, ~s)~nExpected: ~p~nActual:   ~p~n",
+		    [?FILE, ?LINE, ??Actual, Expected@@@, Actual@@@]),
+	     false
+     end)(Expected, Actual) orelse error(badmatch)).
+
+
+%% test callbacks
+all() -> [ipv6prefix].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+%% tests
+
+ipv6prefix(_Config) ->
+    IPv6Prefix0 = {{8193, 0, 0, 0, 0, 0, 0, 0}, 128},
+    ?equal(IPv6Prefix0, ipv6prefix_enc_dec(IPv6Prefix0)),
+
+    IPv6Prefix1 = {{8193, 255, 0, 0, 0, 0, 0, 0}, 128},
+    ?equal(IPv6Prefix1, ipv6prefix_enc_dec(IPv6Prefix1)),
+
+    IPv6Prefix2 = {{8193, 0, 0, 0, 0, 0, 0, 0}, 64},
+    ?equal(IPv6Prefix2, ipv6prefix_enc_dec(IPv6Prefix2)),
+
+    ok.
+
+ipv6prefix_enc_dec(Prefix) ->
+    Bin = eradius_lib:encode_value(ipv6prefix, Prefix),
+    eradius_lib:decode_value(Bin, ipv6prefix).


### PR DESCRIPTION
Before both encoding and decoding were broken by wrong bit syntax.