### PR TITLE
match relays with a regular expression

### DIFF
--- a/src/eradius_config.erl
+++ b/src/eradius_config.erl
@@ -71,9 +71,10 @@ validate_behavior({Module, _, _}) ->
 validate_behavior(Term) ->
     ?invalid("bad Term in Behavior specifification: ~p", [Term]).
 
-validate_arguments({Module, _Nas, Args} = Value) ->
+validate_arguments({Module, Nas, Args} = Value) ->
     case Module:validate_arguments(Args) of
         true -> Value;
+        {true, NewArgs} -> {Module, Nas, NewArgs};
         false -> ?invalid("~p: bad configuration", [Module]);
         Error -> ?invalid("~p: bad configuration: ~p", [Module, Error])
     end.


### PR DESCRIPTION
during making decision where to send a request.
    
From this moment, proxy configuration contains not just a realm/prefix
string, but regular expression.
    
For example:
    
    {routes,
      [{"^test-",  {{127, 0, 0, 1}, 1812, <<"secret1">>}},
       {"*_test$", {{127, 0, 0, 2}, 1813, <<"secret2">>}}]}
    
Requests where realm will be started from `test-`, will
be routed to the first `127.0.0.1:1812` relay.
    
Requests where realm will be ends with `_test`, will be
routed to the second `127.0.0.1:1813` relay.
