### PR TITLE
Fix warning when run common test suites

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,6 +14,12 @@
 {pre_hooks, [{compile, "escript dicts_compiler.erl compile"},
              {clean, "escript dicts_compiler.erl clean"}]}.
 
+{profiles, [
+            {test, [
+                    {erl_opts, [nowarn_export_all]}
+                   ]}
+           ]}.
+
 {cover_enabled, true}.
 {cover_export_enabled, true}.
 {coveralls_service_name, "travis-ci"}.

--- a/test/eradius_client_SUITE.erl
+++ b/test/eradius_client_SUITE.erl
@@ -157,8 +157,8 @@ send(FUN, Ports, Address) ->
 
 wanna_send(_Config) ->
     lists:map(fun(_) ->
-                        IP = {random:uniform(100), random:uniform(100), random:uniform(100), random:uniform(100)},
-                        Port = random:uniform(100),
+                        IP = {rand:uniform(100), rand:uniform(100), rand:uniform(100), rand:uniform(100)},
+                        Port = rand:uniform(100),
                         MetricsInfo = {{undefined, undefined, undefined}, {undefined, undefined, undefined}},
                         FUN = fun() -> gen_server:call(eradius_client, {wanna_send, {undefined, {IP, Port}}, MetricsInfo}) end,
                         send(FUN, null, null)


### PR DESCRIPTION
* test test profile which allows to use export_all without errors
* `random` -> `rand`