### PR TITLE
Proper quoting in doclet

### DIFF
--- a/src/eradius_proxy.erl
+++ b/src/eradius_proxy.erl
@@ -7,11 +7,11 @@
 %%   [{default_route, {{127, 0, 0, 1}, 1813, <<"secret">>}},
 %%    {options, [{type, realm}, {strip, true}, {separator, "@"}]},
 %%    {routes,  [{"^test-[0-9].", {{127, 0, 0, 1}, 1815, <<"secret1">>}}]}],
-%%   ```
+%%   '''
 %%
 %%   == WARNING ==
 %%
-%%   Define `routes` carefully. The `test` here in example above, is
+%%   Define `routes' carefully. The `test' here in example above, is
 %%   a regular expression that may cause to problemts with performance.
 -module(eradius_proxy).
 


### PR DESCRIPTION
Fix improper edoc quoting. 

Before this patch:

```
Auriga ~/work/eradius (git::tags/0.8.7): /usr/bin/rebar doc -vv
...
==> eradius (doc)
DEBUG: "src/eradius_proxy.erl" is more recent than "doc/edoc-info": {{2017,10,30},{18,20,12}} > {{2017,10,30},
                                                                                                 {18,17,58}}
INFO:  Regenerating edocs for eradius
./src/eradius_proxy.erl, in module header: at line 7: ```-quote ended unexpectedly at line 15
edoc: skipping source file './src/eradius_proxy.erl': {'EXIT',error}.
edoc: error in doclet 'edoc_doclet': {'EXIT',error}.
ERROR: doc failed while processing /home/petro/work/eradius: {'EXIT',error}
Auriga ~/work/eradius (git::tags/0.8.7): 
```

With this patch:

```
Auriga ~/work/eradius (git::proper_edoc_quoting): /usr/bin/rebar doc -vv
...
==> eradius (doc)
DEBUG: "src/eradius_proxy.erl" is more recent than "doc/edoc-info": {{2017,10,30},{18,22,39}} > {{2017,10,30},
                                                                                                 {18,20,31}}
INFO:  Regenerating edocs for eradius
DEBUG: Postdirs: []
Auriga ~/work/eradius (git::proper_edoc_quoting):
```