### PR TITLE
Allow 0.0.0.0 as NAS IP to avoid checking source IP

### DIFF
--- a/src/eradius_server_mon.erl
+++ b/src/eradius_server_mon.erl
@@ -47,8 +47,10 @@ reconfigure() ->
 -spec lookup_handler(inet:ip_address(), eradius_server:port_number(), inet:ip_address()) -> {ok, handler(), #nas_prop{}} | {error, not_found}.
 lookup_handler(IP, Port, NasIP) ->
     case ets:lookup(?NAS_TAB, {{IP, Port}, NasIP}) of
-        [] ->
+        [] when NasIP == {0, 0, 0, 0} ->
             {error, not_found};
+        [] ->
+            lookup_handler(IP, Port, {0, 0, 0, 0});
         [Rec] ->
             Prop = (Rec#nas.prop)#nas_prop{server_ip = IP, server_port = Port},
             {ok, Rec#nas.handler, Prop}


### PR DESCRIPTION
In case if NAS declared with 0.0.0.0 as source IP, eradius server
accepts request without checking real IP.