### PR TITLE
RFE: parse $INCLUDE directive in priv/dictionaries/dictionary* files

### DIFF
--- a/priv/dictionaries/dictionary.alcatel
+++ b/priv/dictionaries/dictionary.alcatel
@@ -14,7 +14,7 @@ VENDOR          Alcatel         3041
 ATTRIBUTE       AAT-Client-Primary-DNS          5       ipaddr          Alcatel
 ATTRIBUTE       AAT-Client-Primary-WINS-NBNS    6       ipaddr          Alcatel
 ATTRIBUTE       AAT-Client-Secondary-WINS-NBNS  7       ipaddr          Alcatel
-ATTRIBUTE       AAT-Client-Primary-DNS          8       ipaddr          Alcatel
+ATTRIBUTE       AAT-Client-Secondary-DNS        8       ipaddr          Alcatel
 ATTRIBUTE       AAT-PPP-Address                 9       ipaddr          Alcatel
 ATTRIBUTE       AAT-ATM-Direct                  21      string          Alcatel
 ATTRIBUTE       AAT-IP-TOS                      22      integer         Alcatel

--- a/priv/dictionaries/dictionary.redback
+++ b/priv/dictionaries/dictionary.redback
@@ -1,386 +1,453 @@
+# -*- text -*-
+# Copyright (C) 2015 The FreeRADIUS Server project and contributors
+#
 #
 # Redback dictionary.
-#
-# Version:	1.00  14-Sep-2000  Chris Adams <cmadams@hiwaay.net>
-#		$Id: dictionary.redback,v 1.1 2003/10/27 23:39:40 etnt Exp $
-#
 
-VENDOR		Redback		2352
+VENDOR          Redback         2352
+BEGIN-VENDOR	Redback
 
-#
-#	Redback Vendor Specific Extensions
-#
-#	The first set here uses '-' as the separator, as Redback has changed 
-#	their documentation to utilize '-' vs. '_'.  The older '_' style entries
-#	are listed second so that they will still be accepted, yet not preferred.
-#
-ATTRIBUTE	Client-DNS-Pri			1	ipaddr		Redback
-ATTRIBUTE	Client-DNS-Sec			2	ipaddr		Redback
-ATTRIBUTE	DHCP-Max-Leases			3	integer		Redback
-ATTRIBUTE	Context-Name			4	string		Redback
-ATTRIBUTE	Bridge-Group			5	string		Redback
-ATTRIBUTE	BG-Aging-Time			6	string		Redback
-ATTRIBUTE	BG-Path-Cost			7	string		Redback
-ATTRIBUTE	BG-Span-Dis			8	string		Redback
-ATTRIBUTE	BG-Trans-BPDU			9	string		Redback
-ATTRIBUTE	Rate-Limit-Rate			10	integer		Redback
-ATTRIBUTE	Rate-Limit-Burst		11	integer		Redback
-ATTRIBUTE	Police-Rate			12	integer		Redback
-ATTRIBUTE	Police-Burst			13	integer		Redback
-ATTRIBUTE	Source-Validation		14	integer		Redback
-ATTRIBUTE	Tunnel-Domain			15	integer		Redback
-ATTRIBUTE	Tunnel-Local-Name		16	string		Redback
-ATTRIBUTE	Tunnel-Remote-Name		17	string		Redback
-ATTRIBUTE	Tunnel-Function			18	integer		Redback
-ATTRIBUTE	Tunnel-Max-Sessions		21	integer		Redback
-ATTRIBUTE	Tunnel-Max-Tunnels		22	integer		Redback
-ATTRIBUTE	Tunnel-Session-Auth		23	integer		Redback
-ATTRIBUTE	Tunnel-Window			24	integer		Redback
-ATTRIBUTE	Tunnel-Retransmit		25	integer		Redback
-ATTRIBUTE	Tunnel-Cmd-Timeout		26	integer		Redback
-ATTRIBUTE	PPPOE-URL			27	string		Redback
-ATTRIBUTE	PPPOE-MOTM			28	string		Redback
-ATTRIBUTE	Tunnel-Group			29	integer		Redback
-ATTRIBUTE	Tunnel-Context			30	string		Redback
-ATTRIBUTE	Tunnel-Algorithm		31	integer		Redback
-ATTRIBUTE	Tunnel-Deadtime			32	integer		Redback
-ATTRIBUTE	Mcast-Send			33	integer		Redback
-ATTRIBUTE	Mcast-Receive			34	integer		Redback
-ATTRIBUTE	Mcast-MaxGroups			35	integer		Redback
-ATTRIBUTE	Ip-Address-Pool-Name		36	string		Redback
-ATTRIBUTE	Tunnel-DNIS			37	integer		Redback
-ATTRIBUTE	Medium-Type			38	integer		Redback
-ATTRIBUTE	PVC-Encapsulation-Type		39	integer		Redback
-ATTRIBUTE	PVC-Profile-Name		40	string		Redback
-ATTRIBUTE	PVC-Circuit-Padding		41	integer		Redback
-ATTRIBUTE	Bind-Type			42	integer		Redback
-ATTRIBUTE	Bind-Auth-Protocol		43	integer		Redback
-ATTRIBUTE	Bind-Auth-Max-Sessions		44	integer		Redback
-ATTRIBUTE	Bind-Bypass-Bypass		45	string		Redback
-ATTRIBUTE	Bind-Auth-Context		46	string		Redback
-ATTRIBUTE	Bind-Auth-Service-Grp		47	string		Redback
-ATTRIBUTE	Bind-Bypass-Context		48	string		Redback
-ATTRIBUTE	Bind-Int-Context		49	string		Redback
-ATTRIBUTE	Bind-Tun-Context		50	string		Redback
-ATTRIBUTE	Bind-Ses-Context		51	string		Redback
-ATTRIBUTE	Bind-Dot1q-Slot			52	integer		Redback
-ATTRIBUTE	Bind-Dot1q-Port			53	integer		Redback
-ATTRIBUTE	Bind-Dot1q-Vlan-Tag-Id		54	integer		Redback
-ATTRIBUTE	Bind-Int-Interface-Name		55	string		Redback
-ATTRIBUTE	Bind-L2TP-Tunnel-Name		56	string		Redback
-ATTRIBUTE	Bind-L2TP-Flow-Control		57	integer		Redback
-ATTRIBUTE	Bind-Sub-User-At-Context	58	string		Redback
-ATTRIBUTE	Bind-Sub-Password		59	string		Redback
-ATTRIBUTE	Ip-Host-Addr			60	string		Redback
-ATTRIBUTE	IP-TOS-Field			61	integer		Redback
-ATTRIBUTE	NAS-Real-Port			62	integer		Redback
-ATTRIBUTE	Tunnel-Session-Auth-Ctx		63	string		Redback
-ATTRIBUTE	Tunnel-Session-Auth-Service-Grp	64	string		Redback
-ATTRIBUTE	Tunnel-Rate-Limit-Rate		65	integer		Redback
-ATTRIBUTE	Tunnel-Rate-Limit-Burst		66	integer		Redback
-ATTRIBUTE	Tunnel-Police-Rate		67	integer		Redback
-ATTRIBUTE	Tunnel-Police-Burst		68	integer		Redback
-ATTRIBUTE	Tunnel-L2F-Second-Password	69	string		Redback
-ATTRIBUTE	Acct-Input-Octets-64		128	octets		Redback
-ATTRIBUTE	Acct-Output-Octets-64		129	octets		Redback
-ATTRIBUTE	Acct-Input-Packets-64		130	octets		Redback
-ATTRIBUTE	Acct-Output-Packets-64		131	octets		Redback
-ATTRIBUTE	Assigned-IP-Address		132	ipaddr		Redback
-ATTRIBUTE	Acct-Mcast-In-Octets		133	integer		Redback
-ATTRIBUTE	Acct-Mcast-Out-Octets		134	integer		Redback
-ATTRIBUTE	Acct-Mcast-In-Packets		135	integer		Redback
-ATTRIBUTE	Acct-Mcast-Out-Packets		136	integer		Redback
-ATTRIBUTE	LAC-Port			137	integer		Redback
-ATTRIBUTE	LAC-Real-Port			138	integer		Redback
-ATTRIBUTE	LAC-Port-Type			139	integer		Redback
-ATTRIBUTE	LAC-Real-Port-Type		140	integer		Redback
-ATTRIBUTE	Acct-Dyn-Ac-Ent			141	string		Redback
-ATTRIBUTE	Session-Error-Code		142	integer		Redback
-ATTRIBUTE	Session-Error-Msg		143	string		Redback
+ATTRIBUTE	Client-DNS-Pri				1	ipaddr
+ATTRIBUTE	Client-DNS-Sec				2	ipaddr
+ATTRIBUTE	DHCP-Max-Leases				3	integer
+ATTRIBUTE	Context-Name				4	string
+ATTRIBUTE	Bridge-Group				5	string
+ATTRIBUTE	BG-Aging-Time				6	string
+ATTRIBUTE	BG-Path-Cost				7	string
+ATTRIBUTE	BG-Span-Dis				8	string
+ATTRIBUTE	BG-Trans-BPDU				9	string
+ATTRIBUTE	Rate-Limit-Rate				10	integer
+ATTRIBUTE	Rate-Limit-Burst			11	integer
+ATTRIBUTE	Police-Rate				12	integer
+ATTRIBUTE	Police-Burst				13	integer
+ATTRIBUTE	Source-Validation			14	integer
 
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-ATM-RAW		1
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-ATM-ROUTE1483	2
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-ATM-AUTO1483		3
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-ATM-MULTI		4
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-ATM-BRIDGE1483	5
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-ATM-PPP		6
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-ATM-PPP-SERIAL	7
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-ATM-PPP-NLPID	8
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-ATM-PPP-AUTO		9
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-ATM-PPPOE		10
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-ATM-L2TP		11
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-ATM-PPP-LLC		12
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-FRAME-AUTO1490	13
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-FRAME-MULTI		14
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-FRAME-BRIDGE1490	15
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-FRAME-PPP		16
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-FRAME-PPP-AUTO	17
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-FRAME-PPPOE		18
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-FRAME-ROUTE1490	19
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-FRAME-L2TP		20
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-L2TP-VC-MUXED	21
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-ETH			22
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-ETH-PPPOE		23
-VALUE	PVC-Encapsulation-Type	AAA-ENCAPS-ETH-MULTI		24
-VALUE	PVC-Circuit-Padding	AAA-CIRCUIT-PADDING		1
-VALUE	PVC-Circuit-Padding	AAA-CIRCUIT-NO-PADDING		2
-VALUE	Bind-Type		AAA-AUTH-BIND			1
-VALUE	Bind-Type		AAA-BYPASS-BIND			2
-VALUE	Bind-Type		AAA-INTERFACE-BIND		3
-VALUE	Bind-Type		AAA-SUBSCRIBE-BIND		4
-VALUE	Bind-Type		AAA-TUNNEL-BIND			5
-VALUE	Bind-Type		AAA-SESSION-BIND		6
-VALUE	Bind-Type		AAA-Q8021-BIND			7
-VALUE	Bind-Type		AAA-MULTI-BIND			8
-VALUE	Bind-Auth-Protocol	AAA-PPP-PAP			1
-VALUE	Bind-Auth-Protocol	AAA-PPP-CHAP			2
-VALUE	Bind-Auth-Protocol	AAA-PPP-CHAP-WAIT		3
-VALUE	Bind-Auth-Protocol	AAA-PPP-CHAP-PAP		4
-VALUE	Bind-Auth-Protocol	AAA-PPP-CHAP-WAIT-PAP		5
+VALUE	Source-Validation		Enabled			1
+VALUE	Source-Validation		Disabled		2
 
-VALUE	Tunnel-Function		LAC-Only			1
-VALUE	Tunnel-Function		LNS-Only			2
-VALUE	Tunnel-Function		LAC-LNS				3
-VALUE	Tunnel-Session-Auth	CHAP				1
-VALUE	Tunnel-Session-Auth	PAP				2
-VALUE	Tunnel-Session-Auth	CHAP-PAP			3
-VALUE	Mcast-Send		NO-SEND				1
-VALUE	Mcast-Send		SEND				2
-VALUE	Mcast-Send		UNSOLICITED-SEND		3
-VALUE	Mcast-Receive		NO-RECEIVE			1
-VALUE	Mcast-Receive		RECEIVE				2
+ATTRIBUTE	Tunnel-Domain				15	integer
 
-VALUE	Tunnel-DNIS		DNIS				1
-VALUE	Tunnel-DNIS		DNIS-Only			2
+VALUE	Tunnel-Domain			Enabled			1
+VALUE	Tunnel-Domain			Disabled		2
 
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-10BT		40
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-100BT		41
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-DS3-FR		42
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-DS3-ATM		43
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-OC3		44
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-HSSI		45
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-EIA530		46
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-T1		47
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-CHAN-T3		48
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-DS1-FR		49
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-E3-ATM		50
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-IMA-ATM		51
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-DS3-ATM-2		52
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-OC3-ATM-2		53
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-1000BSX		54
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-E1-FR		55
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-E1-ATM		56
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-E3-FR		57
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-OC3-POS		58
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-OC12-POS		59
-VALUE	LAC-Port-Type		NAS-PORT-TYPE-PPPOE		60
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-10BT		40
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-100BT		41
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-DS3-FR		42
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-DS3-ATM		43
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-OC3		44
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-HSSI		45
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-EIA530		46
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-T1		47
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-CHAN-T3		48
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-DS1-FR		49
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-E3-ATM		50
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-IMA-ATM		51
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-DS3-ATM-2		52
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-OC3-ATM-2		53
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-1000BSX		54
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-E1-FR		55
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-E1-ATM		56
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-E3-FR		57
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-OC3-POS		58
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-OC12-POS		59
-VALUE	LAC-Real-Port-Type	NAS-PORT-TYPE-PPPOE		60
+ATTRIBUTE	Tunnel-Local-Name			16	string
+ATTRIBUTE	Tunnel-Remote-Name			17	string
+ATTRIBUTE	Tunnel-Function				18	integer
 
-#
-#	Redback Vendor Specific Extensions  ( older style syntax )
-#
-#	The names use underscores (_) instead of dashes (-), because
-#	that's what Redback used in their older documentation and examples.
-#
-ATTRIBUTE	Client_DNS_Pri			1	ipaddr		Redback
-ATTRIBUTE	Client_DNS_Sec			2	ipaddr		Redback
-ATTRIBUTE	DHCP_Max_Leases			3	integer		Redback
-ATTRIBUTE	Context-Name			4	string		Redback
-ATTRIBUTE	Bridge_Group			5	string		Redback
-ATTRIBUTE	BG_Aging_Time			6	string		Redback
-ATTRIBUTE	BG_Path_Cost			7	string		Redback
-ATTRIBUTE	BG_Span_Dis			8	string		Redback
-ATTRIBUTE	BG_Trans_BPDU			9	string		Redback
-ATTRIBUTE	Rate_Limit_Rate			10	integer		Redback
-ATTRIBUTE	Rate_Limit_Burst		11	integer		Redback
-ATTRIBUTE	Police_Rate			12	integer		Redback
-ATTRIBUTE	Police_Burst			13	integer		Redback
-ATTRIBUTE	Source_Validation		14	integer		Redback
-ATTRIBUTE	Tunnel_Domain			15	integer		Redback
-ATTRIBUTE	Tunnel_Local_Name		16	string		Redback
-ATTRIBUTE	Tunnel_Remote_Name		17	string		Redback
-ATTRIBUTE	Tunnel_Function			18	integer		Redback
-ATTRIBUTE	Tunnel_Max_Sessions		21	integer		Redback
-ATTRIBUTE	Tunnel_Max_Tunnels		22	integer		Redback
-ATTRIBUTE	Tunnel_Session_Auth		23	integer		Redback
-ATTRIBUTE	Tunnel_Window			24	integer		Redback
-ATTRIBUTE	Tunnel_Retransmit		25	integer		Redback
-ATTRIBUTE	Tunnel_Cmd_Timeout		26	integer		Redback
-ATTRIBUTE	PPPOE_URL			27	string		Redback
-ATTRIBUTE	PPPOE_MOTM			28	string		Redback
-ATTRIBUTE	Tunnel_Group			29	integer		Redback
-ATTRIBUTE	Tunnel_Context			30	string		Redback
-ATTRIBUTE	Tunnel_Algorithm		31	integer		Redback
-ATTRIBUTE	Tunnel_Deadtime			32	integer		Redback
-ATTRIBUTE	Mcast_Send			33	integer		Redback
-ATTRIBUTE	Mcast_Receive			34	integer		Redback
-ATTRIBUTE	Mcast_MaxGroups			35	integer		Redback
-ATTRIBUTE	Ip_Address_Pool_Name		36	string		Redback
-ATTRIBUTE	Tunnel_DNIS			37	integer		Redback
-ATTRIBUTE	Medium_Type			38	integer		Redback
-ATTRIBUTE	PVC_Encapsulation_Type		39	integer		Redback
-ATTRIBUTE	PVC_Profile_Name		40	string		Redback
-ATTRIBUTE	PVC_Circuit_Padding		41	integer		Redback
-ATTRIBUTE	Bind_Type			42	integer		Redback
-ATTRIBUTE	Bind_Auth_Protocol		43	integer		Redback
-ATTRIBUTE	Bind_Auth_Max_Sessions		44	integer		Redback
-ATTRIBUTE	Bind_Bypass_Bypass		45	string		Redback
-ATTRIBUTE	Bind_Auth_Context		46	string		Redback
-ATTRIBUTE	Bind_Auth_Service_Grp		47	string		Redback
-ATTRIBUTE	Bind_Bypass_Context		48	string		Redback
-ATTRIBUTE	Bind_Int_Context		49	string		Redback
-ATTRIBUTE	Bind_Tun_Context		50	string		Redback
-ATTRIBUTE	Bind_Ses_Context		51	string		Redback
-ATTRIBUTE	Bind_Dot1q_Slot			52	integer		Redback
-ATTRIBUTE	Bind_Dot1q_Port			53	integer		Redback
-ATTRIBUTE	Bind_Dot1q_Vlan_Tag_Id		54	integer		Redback
-ATTRIBUTE	Bind_Int_Interface_Name		55	string		Redback
-ATTRIBUTE	Bind_L2TP_Tunnel_Name		56	string		Redback
-ATTRIBUTE	Bind_L2TP_Flow_Control		57	integer		Redback
-ATTRIBUTE	Bind_Sub_User_At_Context	58	string		Redback
-ATTRIBUTE	Bind_Sub_Password		59	string		Redback
-ATTRIBUTE	Ip_Host_Addr			60	string		Redback
-ATTRIBUTE	IP_TOS_Field			61	integer		Redback
-ATTRIBUTE	NAS_Real_Port			62	integer		Redback
-ATTRIBUTE	Tunnel_Session_Auth_Ctx		63	string		Redback
-ATTRIBUTE	Tunnel_Session_Auth_Service_Grp	64	string		Redback
-ATTRIBUTE	Tunnel_Rate_Limit_Rate		65	integer		Redback
-ATTRIBUTE	Tunnel_Rate_Limit_Burst		66	integer		Redback
-ATTRIBUTE	Tunnel_Police_Rate		67	integer		Redback
-ATTRIBUTE	Tunnel_Police_Burst		68	integer		Redback
-ATTRIBUTE	Tunnel_L2F_Second_Password	69	string		Redback
-ATTRIBUTE	Acct_Input_Octets_64		128	octets		Redback
-ATTRIBUTE	Acct_Output_Octets_64		129	octets		Redback
-ATTRIBUTE	Acct_Input_Packets_64		130	octets		Redback
-ATTRIBUTE	Acct_Output_Packets_64		131	octets		Redback
-ATTRIBUTE	Assigned_IP_Address		132	ipaddr		Redback
-ATTRIBUTE	Acct_Mcast_In_Octets		133	integer		Redback
-ATTRIBUTE	Acct_Mcast_Out_Octets		134	integer		Redback
-ATTRIBUTE	Acct_Mcast_In_Packets		135	integer		Redback
-ATTRIBUTE	Acct_Mcast_Out_Packets		136	integer		Redback
-ATTRIBUTE	LAC_Port			137	integer		Redback
-ATTRIBUTE	LAC_Real_Port			138	integer		Redback
-ATTRIBUTE	LAC_Port_Type			139	integer		Redback
-ATTRIBUTE	LAC_Real_Port_Type		140	integer		Redback
-ATTRIBUTE	Acct_Dyn_Ac_Ent			141	string		Redback
-ATTRIBUTE	Session_Error_Code		142	integer		Redback
-ATTRIBUTE	Session_Error_Msg		143	string		Redback
+VALUE	Tunnel-Function			LAC-Only		1
+VALUE	Tunnel-Function			LNS-Only		2
+VALUE	Tunnel-Function			LAC-LNS			3
 
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_ATM_RAW		1
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_ATM_ROUTE1483	2
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_ATM_AUTO1483		3
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_ATM_MULTI		4
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_ATM_BRIDGE1483	5
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_ATM_PPP		6
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_ATM_PPP_SERIAL	7
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_ATM_PPP_NLPID	8
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_ATM_PPP_AUTO		9
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_ATM_PPPOE		10
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_ATM_L2TP		11
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_ATM_PPP_LLC		12
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_FRAME_AUTO1490	13
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_FRAME_MULTI		14
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_FRAME_BRIDGE1490	15
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_FRAME_PPP		16
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_FRAME_PPP_AUTO	17
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_FRAME_PPPOE		18
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_FRAME_ROUTE1490	19
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_FRAME_L2TP		20
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_L2TP_VC_MUXED	21
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_ETH			22
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_ETH_PPPOE		23
-VALUE	PVC_Encapsulation_Type	AAA_ENCAPS_ETH_MULTI		24
-VALUE	PVC_Circuit_Padding	AAA_CIRCUIT_PADDING		1
-VALUE	PVC_Circuit_Padding	AAA_CIRCUIT_NO_PADDING		2
-VALUE	Bind_Type		AAA_AUTH_BIND			1
-VALUE	Bind_Type		AAA_BYPASS_BIND			2
-VALUE	Bind_Type		AAA_INTERFACE_BIND		3
-VALUE	Bind_Type		AAA_SUBSCRIBE_BIND		4
-VALUE	Bind_Type		AAA_TUNNEL_BIND			5
-VALUE	Bind_Type		AAA_SESSION_BIND		6
-VALUE	Bind_Type		AAA_Q8021_BIND			7
-VALUE	Bind_Type		AAA_MULTI_BIND			8
-VALUE	Bind_Auth_Protocol	AAA_PPP_PAP			1
-VALUE	Bind_Auth_Protocol	AAA_PPP_CHAP			2
-VALUE	Bind_Auth_Protocol	AAA_PPP_CHAP_WAIT		3
-VALUE	Bind_Auth_Protocol	AAA_PPP_CHAP_PAP		4
-VALUE	Bind_Auth_Protocol	AAA_PPP_CHAP_WAIT_PAP		5
+ATTRIBUTE	Tunnel-Flow-Control			19	integer
+ATTRIBUTE	Tunnel-Static				20	integer
+ATTRIBUTE	Tunnel-Max-Sessions			21	integer
+ATTRIBUTE	Tunnel-Max-Tunnels			22	integer
+ATTRIBUTE	Tunnel-Session-Auth			23	integer
 
-VALUE	Tunnel_Function		LAC-Only			1
-VALUE	Tunnel_Function		LNS-Only			2
-VALUE	Tunnel_Function		LAC-LNS				3
-VALUE	Tunnel_Session_Auth	CHAP				1
-VALUE	Tunnel_Session_Auth	PAP				2
-VALUE	Tunnel_Session_Auth	CHAP-PAP			3
-VALUE	Mcast_Send		NO-SEND				1
-VALUE	Mcast_Send		SEND				2
-VALUE	Mcast_Send		UNSOLICITED-SEND		3
-VALUE	Mcast_Receive		NO-RECEIVE			1
-VALUE	Mcast_Receive		RECEIVE				2
+VALUE	Tunnel-Session-Auth		CHAP			1
+VALUE	Tunnel-Session-Auth		PAP			2
+VALUE	Tunnel-Session-Auth		CHAP-PAP		3
 
-VALUE	Tunnel_DNIS		DNIS				1
-VALUE	Tunnel_DNIS		DNIS-Only			2
+ATTRIBUTE	Tunnel-Window				24	integer
+ATTRIBUTE	Tunnel-Retransmit			25	integer
+ATTRIBUTE	Tunnel-Cmd-Timeout			26	integer
+ATTRIBUTE	PPPOE-URL				27	string
+ATTRIBUTE	PPPOE-MOTM				28	string
+ATTRIBUTE	Tunnel-Group				29	integer
 
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_10BT		40
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_100BT		41
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_DS3_FR		42
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_DS3_ATM		43
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_OC3		44
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_HSSI		45
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_EIA530		46
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_T1		47
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_CHAN_T3		48
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_DS1_FR		49
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_E3_ATM		50
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_IMA_ATM		51
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_DS3_ATM_2		52
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_OC3_ATM_2		53
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_1000BSX		54
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_E1_FR		55
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_E1_ATM		56
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_E3_FR		57
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_OC3_POS		58
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_OC12_POS		59
-VALUE	LAC_Port_Type		NAS_PORT_TYPE_PPPOE		60
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_10BT		40
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_100BT		41
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_DS3_FR		42
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_DS3_ATM		43
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_OC3		44
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_HSSI		45
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_EIA530		46
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_T1		47
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_CHAN_T3		48
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_DS1_FR		49
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_E3_ATM		50
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_IMA_ATM		51
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_DS3_ATM_2		52
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_OC3_ATM_2		53
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_1000BSX		54
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_E1_FR		55
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_E1_ATM		56
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_E3_FR		57
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_OC3_POS		58
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_OC12_POS		59
-VALUE	LAC_Real_Port_Type	NAS_PORT_TYPE_PPPOE		60
+VALUE	Tunnel-Group			Enabled			1
+VALUE	Tunnel-Group			Disabled		2
 
+ATTRIBUTE	Tunnel-Context				30	string
+ATTRIBUTE	Tunnel-Algorithm			31	integer
+
+VALUE	Tunnel-Algorithm		First			1
+VALUE	Tunnel-Algorithm		Load-Balance		2
+VALUE	Tunnel-Algorithm		WRR			3
+
+ATTRIBUTE	Tunnel-Deadtime				32	integer
+ATTRIBUTE	Mcast-Send				33	integer
+
+VALUE	Mcast-Send			NO-SEND			1
+VALUE	Mcast-Send			SEND			2
+VALUE	Mcast-Send			UNSOLICITED-SEND	3
+
+ATTRIBUTE	Mcast-Receive				34	integer
+
+VALUE	Mcast-Receive			NO-RECEIVE		1
+VALUE	Mcast-Receive			RECEIVE			2
+
+ATTRIBUTE	Mcast-MaxGroups				35	integer
+ATTRIBUTE	Ip-Address-Pool-Name			36	string
+ATTRIBUTE	Tunnel-DNIS				37	integer
+
+VALUE	Tunnel-DNIS			DNIS			1
+VALUE	Tunnel-DNIS			DNIS-Only		2
+VALUE	Tunnel-DNIS			DNIS-Generate		4
+
+ATTRIBUTE	Medium-Type				38	integer
+
+VALUE	Medium-Type			DSL			11
+VALUE	Medium-Type			Cable			12
+VALUE	Medium-Type			Wireless		13
+VALUE	Medium-Type			Satellite		14
+
+ATTRIBUTE	PVC-Encapsulation-Type			39	integer
+
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ATM-RAW	1
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ATM-ROUTE1483 2
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ATM-AUTO1483	3
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ATM-MULTI	4
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ATM-BRIDGE1483 5
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ATM-PPP	6
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ATM-PPP-SERIAL 7
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ATM-PPP-NLPID 8
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ATM-PPP-AUTO	9
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ATM-PPPOE	10
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ATM-L2TP	11
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ATM-PPP-LLC	12
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-FRAME-AUTO1490 13
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-FRAME-MULTI	14
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-FRAME-BRIDGE1490 15
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-FRAME-PPP	16
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-FRAME-PPP-AUTO 17
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-FRAME-PPPOE	18
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-FRAME-ROUTE1490 19
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-FRAME-L2TP	20
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-L2TP-VC-MUXED 21
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ETH		22
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ETH-PPPOE	23
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ETH-MULTI	24
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ETH-DOT1Q	25
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ETH-DOT1Q-PPPOE 26
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ATM-MULTI-PPPOE 27
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ATM-MULTI-IPV6OE 28
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ATM-MULTI-PPPOE-N-IPV6OE 29
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ETH-DOT1Q-TUNNEL 30
+VALUE	PVC-Encapsulation-Type		AAA-ENCAPS-ETH-DOT1Q-TUNNEL-PPPOE 31
+
+ATTRIBUTE	PVC-Profile-Name			40	string
+ATTRIBUTE	PVC-Circuit-Padding			41	integer
+
+VALUE	PVC-Circuit-Padding		AAA-CIRCUIT-PADDING	1
+VALUE	PVC-Circuit-Padding		AAA-CIRCUIT-NO-PADDING	2
+
+ATTRIBUTE	Bind-Type				42	integer
+
+VALUE	Bind-Type			AAA-AUTH-BIND		1
+VALUE	Bind-Type			AAA-BYPASS-BIND		2
+VALUE	Bind-Type			AAA-INTERFACE-BIND	3
+VALUE	Bind-Type			AAA-SUBSCRIBE-BIND	4
+VALUE	Bind-Type			AAA-TUNNEL-BIND		5
+VALUE	Bind-Type			AAA-SESSION-BIND	6
+VALUE	Bind-Type			AAA-Q8021-BIND		7
+VALUE	Bind-Type			AAA-MULTI-BIND		8
+VALUE	Bind-Type			AAA-DHCP-BIND		9
+VALUE	Bind-Type			AAA-MULTI-BIND-SUB	10
+VALUE	Bind-Type			AAA-BRIDGE-GROUP-BIND	11
+VALUE	Bind-Type			AAA-VLAN-BIND		12
+VALUE	Bind-Type			AAA-VLAN-GROUP-BIND	13
+VALUE	Bind-Type			AAA-AUTO-SUBSCRIBER-BIND 14
+
+ATTRIBUTE	Bind-Auth-Protocol			43	integer
+
+VALUE	Bind-Auth-Protocol		AAA-PPP-PAP		1
+VALUE	Bind-Auth-Protocol		AAA-PPP-CHAP		2
+VALUE	Bind-Auth-Protocol		AAA-PPP-CHAP-WAIT	3
+VALUE	Bind-Auth-Protocol		AAA-PPP-CHAP-PAP	4
+VALUE	Bind-Auth-Protocol		AAA-PPP-CHAP-WAIT-PAP	5
+VALUE	Bind-Auth-Protocol		AAA-PPP-EAP		6
+VALUE	Bind-Auth-Protocol		AAA-PPP-PAP-CHAP	7
+VALUE	Bind-Auth-Protocol		AAA-PPP-PAP-CHAP-WAIT	8
+
+ATTRIBUTE	Bind-Auth-Max-Sessions			44	integer
+ATTRIBUTE	Bind-Bypass-Bypass			45	string
+ATTRIBUTE	Bind-Auth-Context			46	string
+ATTRIBUTE	Bind-Auth-Service-Grp			47	string
+ATTRIBUTE	Bind-Bypass-Context			48	string
+ATTRIBUTE	Bind-Int-Context			49	string
+ATTRIBUTE	Bind-Tun-Context			50	string
+ATTRIBUTE	Bind-Ses-Context			51	string
+ATTRIBUTE	Bind-Dot1q-Slot				52	integer
+ATTRIBUTE	Bind-Dot1q-Port				53	integer
+ATTRIBUTE	Bind-Dot1q-Vlan-Tag-Id			54	integer
+ATTRIBUTE	Bind-Int-Interface-Name			55	string
+ATTRIBUTE	Bind-L2TP-Tunnel-Name			56	string
+ATTRIBUTE	Bind-L2TP-Flow-Control			57	integer
+ATTRIBUTE	Bind-Sub-User-At-Context		58	string
+ATTRIBUTE	Bind-Sub-Password			59	string
+ATTRIBUTE	Ip-Host-Addr				60	string
+ATTRIBUTE	IP-Tos-Field				61	integer
+
+VALUE	IP-TOS-Field			normal			0
+VALUE	IP-TOS-Field			min-cost-only		1
+VALUE	IP-TOS-Field			max-reliability-only	2
+VALUE	IP-TOS-Field			max-reliability-plus-min-cost 3
+VALUE	IP-TOS-Field			max-throughput-only	4
+VALUE	IP-TOS-Field			max-throughput-plus-min-cost 5
+VALUE	IP-TOS-Field			max-throughput-plus-max-reliability 6
+VALUE	IP-TOS-Field			max-throughput-plus-max-reliability-plus-min-cost 7
+VALUE	IP-TOS-Field			min-delay-only		8
+VALUE	IP-TOS-Field			min-delay-plus-min-cost	9
+VALUE	IP-TOS-Field			min-delay-plus-max-reliability 10
+VALUE	IP-TOS-Field			min-delay-plus-max-reliability-plus-min-cost 11
+VALUE	IP-TOS-Field			min-delay-plus-max-throughput 12
+VALUE	IP-TOS-Field			min-delay-plus-max-throughput-plus-min-cost 13
+VALUE	IP-TOS-Field			min-delay-plus-max-throughput-plus-max-reliability 14
+VALUE	IP-TOS-Field			min-delay-plus-max-throughput-plus-max-reliability-plus-min-cost 15
+
+ATTRIBUTE	NAS-Real-Port				62	integer
+ATTRIBUTE	Tunnel-Session-Auth-Ctx			63	string
+ATTRIBUTE	Tunnel-Session-Auth-Service-Grp		64	string
+ATTRIBUTE	Tunnel-Rate-Limit-Rate			65	integer
+ATTRIBUTE	Tunnel-Rate-Limit-Burst			66	integer
+ATTRIBUTE	Tunnel-Police-Rate			67	integer
+ATTRIBUTE	Tunnel-Police-Burst			68	integer
+ATTRIBUTE	Tunnel-L2F-Second-Password		69	string
+ATTRIBUTE	ACL-Definition				70	string
+ATTRIBUTE	PPPoE-IP-Route-Add			71	string
+ATTRIBUTE	TTY-Level-Max				72	integer
+ATTRIBUTE	TTY-Level-Start				73	integer
+ATTRIBUTE	Tunnel-Checksum				74	integer
+ATTRIBUTE	Tunnel-Profile				75	string
+ATTRIBUTE	Tunnel-Client-VPN			78	string
+ATTRIBUTE	Tunnel-Server-VPN			79	string
+ATTRIBUTE	Tunnel-Client-Rhost			80	string
+ATTRIBUTE	Tunnel-Server-Rhost			81	string
+ATTRIBUTE	Tunnel-Client-Int-Addr			82	ipaddr
+ATTRIBUTE	Tunnel-Server-Int-Addr			83	ipaddr
+ATTRIBUTE	PPP-Compression				84	integer
+ATTRIBUTE	Tunnel-Hello-Timer			85	integer has_tag
+ATTRIBUTE	Redback-Reason				86	integer
+ATTRIBUTE	Qos-Policing-Profile-Name		87	string
+ATTRIBUTE	Qos-Metering-Profile-Name		88	string
+ATTRIBUTE	Qos-Policy-Queuing			89	string
+ATTRIBUTE	IGMP-Service-Profile-Name		90	string
+ATTRIBUTE	Subscriber-Profile-Name			91	string
+ATTRIBUTE	Forward-Policy				92	string
+ATTRIBUTE	Remote-Port				93	string
+ATTRIBUTE	Reauth					94	string
+ATTRIBUTE	Reauth-More				95	integer
+ATTRIBUTE	Agent-Remote-Id				96	octets
+ATTRIBUTE	Agent-Circuit-Id			97	octets
+ATTRIBUTE	Platform-Type				98	integer
+
+VALUE	Platform-Type			SMS			1
+VALUE	Platform-Type			SmartEdge-800		2
+VALUE	Platform-Type			SE-400			3
+VALUE	Platform-Type			SE-100			4
+
+ATTRIBUTE	Client-NBNS-Pri				99	ipaddr
+ATTRIBUTE	Client-NBNS-Sec				100	ipaddr
+ATTRIBUTE	Shaping-Profile-Name			101	string
+ATTRIBUTE	BG-Cct-Addr-Max				103	integer
+ATTRIBUTE	IP-Interface-Name			104	string
+ATTRIBUTE	NAT-Policy-Name				105	string
+ATTRIBUTE	RB-NPM-Service-Id			106	string
+ATTRIBUTE	HTTP-Redirect-Profile-Name		107	string
+ATTRIBUTE	Bind-Auto-Sub-User			108	string
+ATTRIBUTE	Bind-Auto-Sub-Context			109	string
+ATTRIBUTE	Bind-Auto-Sub-Password			110	string
+ATTRIBUTE	Circuit-Protocol-Encap			111	integer
+
+VALUE	Circuit-Protocol-Encap		ENCAPS-PPPOE		27
+
+ATTRIBUTE	OS-Version				112	string
+ATTRIBUTE	Session-Traffic-Limit			113	string
+ATTRIBUTE	QOS-Reference				114	string
+ATTRIBUTE	Rate-Limit-Excess-Burst			121	octets
+ATTRIBUTE	Police-Excess-Burst			122	octets
+ATTRIBUTE	Tunnel-Rate-Limit-Excess-Burst		123	octets
+ATTRIBUTE	Tunnel-Police-Excess-Burst		124	octets
+ATTRIBUTE	DHCP-Vendor-Class-ID			125	string
+ATTRIBUTE	Qos-Rate				126	string
+ATTRIBUTE	DHCP-Vendor-Encap-Option		127	string
+ATTRIBUTE	Acct-Input-Octets-64			128	integer64
+ATTRIBUTE	Acct-Output-Octets-64			129	integer64
+ATTRIBUTE	Acct-Input-Packets-64			130	integer64
+ATTRIBUTE	Acct-Output-Packets-64			131	integer64
+ATTRIBUTE	Assigned-IP-Address			132	ipaddr
+ATTRIBUTE	Acct-Mcast-In-Octets-64			133	integer64
+ATTRIBUTE	Acct-Mcast-Out-Octets-64		134	integer64
+ATTRIBUTE	Acct-Mcast-In-Packets-64		135	integer64
+ATTRIBUTE	Acct-Mcast-Out-Packets-64		136	integer64
+ATTRIBUTE	LAC-Port				137	integer
+ATTRIBUTE	LAC-Real-Port				138	integer
+ATTRIBUTE	LAC-Port-Type				139	integer
+
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-10BT	40
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-100BT	41
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-DS3-FR	42
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-DS3-ATM	43
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-OC3	44
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-HSSI	45
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-EIA530	46
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-T1	47
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-CHAN-T3	48
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-DS1-FR	49
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-E3-ATM	50
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-IMA-ATM	51
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-DS3-ATM-2	52
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-OC3-ATM-2	53
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-1000BSX	54
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-E1-FR	55
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-E1-ATM	56
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-E3-FR	57
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-OC3-POS	58
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-OC12-POS	59
+VALUE	LAC-Port-Type			NAS-PORT-TYPE-PPPOE	60
+
+ATTRIBUTE	LAC-Real-Port-Type			140	integer
+
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-10BT	40
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-100BT	41
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-DS3-FR	42
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-DS3-ATM	43
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-OC3	44
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-HSSI	45
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-EIA530	46
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-T1	47
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-CHAN-T3	48
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-DS1-FR	49
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-E3-ATM	50
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-IMA-ATM	51
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-DS3-ATM-2	52
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-OC3-ATM-2	53
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-1000BSX	54
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-E1-FR	55
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-E1-ATM	56
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-E3-FR	57
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-OC3-POS	58
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-OC12-POS	59
+VALUE	LAC-Real-Port-Type		NAS-PORT-TYPE-PPPOE	60
+
+ATTRIBUTE	Acct-Dyn-Ac-Ent				141	string
+ATTRIBUTE	Session-Error-Code			142	integer
+ATTRIBUTE	Session-Error-Msg			143	string
+ATTRIBUTE	Acct-Update-Reason			144	integer
+
+VALUE	Acct-Update-Reason		AAA-LOAD-ACCT-SESSION-UP 1
+VALUE	Acct-Update-Reason		AAA-LOAD-ACCT-SESSION-DOWN 2
+VALUE	Acct-Update-Reason		AAA-LOAD-ACCT-PERIODIC	3
+VALUE	Acct-Update-Reason		AAA-LOAD-ACCT-DYN-AC-ENT-START 4
+VALUE	Acct-Update-Reason		AAA-LOAD-ACCT-DYN-AC-ENT-STOP 5
+VALUE	Acct-Update-Reason		AAA-LOAD-ACCT-DYN-AC-ENT-TIMEOUT 6
+VALUE	Acct-Update-Reason		AAA-LOAD-ACCT-SUBSCRIBER-REAUTHOR 7
+VALUE	Acct-Update-Reason		AAA-LOAD-ACCT-PPP-IPCP-UP 8
+VALUE	Acct-Update-Reason		AAA-LOAD-ACCT-PPP-MP-LINK-UP 9
+VALUE	Acct-Update-Reason		AAA-LOAD-ACCT-DHCP-IP-ADDR-GRANTED 10
+VALUE	Acct-Update-Reason		AAA-LOAD-ACCT-DHCP-IP-ADDR-RELEASED 11
+VALUE	Acct-Update-Reason		AAA-LOAD-ACCT-ACL-TIMERED-ACTION 12
+VALUE	Acct-Update-Reason		AAA-LOAD-ACCT-ACL-ACTION 13
+VALUE	Acct-Update-Reason		AAA-LOAD-ACCT-CMD	14
+VALUE	Acct-Update-Reason		AAA-LOAD-ACCT-TEST	15
+
+ATTRIBUTE	Mac-Addr				145	string
+ATTRIBUTE	Vlan-Source-Info			146	string
+ATTRIBUTE	Acct-Mcast-In-Octets			147	integer
+ATTRIBUTE	Acct-Mcast-Out-Octets			148	integer
+ATTRIBUTE	Acct-Mcast-In-Packets			149	integer
+ATTRIBUTE	Acct-Mcast-Out-Packets			150	integer
+ATTRIBUTE	Reauth-Session-Id			151	string
+ATTRIBUTE	QOS-Rate-Inbound			156	string
+ATTRIBUTE	QOS-Rate-Outbound			157	string
+ATTRIBUTE	Route-Tag				158	integer
+ATTRIBUTE	LI-Id					159	integer
+ATTRIBUTE	LI-Md-Address				160	ipaddr
+ATTRIBUTE	LI-Md-Port				161	integer
+ATTRIBUTE	LI-Action				162	integer
+ATTRIBUTE	LI-Profile				163	string
+ATTRIBUTE	Dynamic-Policy-Filter			164	string
+ATTRIBUTE	HTTP-Redirect-URL			165	string
+ATTRIBUTE	DSL-Actual-Rate-Up			166	integer
+ATTRIBUTE	DSL-Actual-Rate-Down			167	integer
+ATTRIBUTE	DSL-Min-Rate-Up				168	integer
+ATTRIBUTE	DSL-Min-Rate-Down			169	integer
+ATTRIBUTE	DSL-Attainable-Rate-Up			170	integer
+ATTRIBUTE	DSL-Attainable-Rate-Down		171	integer
+ATTRIBUTE	DSL-Max-Rate-Up				172	integer
+ATTRIBUTE	DSL-Max-Rate-Down			173	integer
+ATTRIBUTE	DSL-Min-Low-Power-Rate-Up		174	integer
+ATTRIBUTE	DSL-Min-Low-Power-Rate-Down		175	integer
+ATTRIBUTE	DSL-Max-Inter-Delay-Up			176	integer
+ATTRIBUTE	DSL-Actual-Inter-Delay-Up		177	integer
+ATTRIBUTE	DSL-Max-Inter-Delay-Down		178	integer
+ATTRIBUTE	DSL-Actual-Inter-Delay-Down		179	integer
+ATTRIBUTE	DSL-Line-State				180	integer
+
+VALUE	DSL-Line-State			Showtime		1
+VALUE	DSL-Line-State			Idle			2
+VALUE	DSL-Line-State			Silent			3
+
+ATTRIBUTE	DSL-L2-Encapsulation			181	integer
+ATTRIBUTE	DSL-Transmission-System			182	integer
+
+VALUE	DSL-Transmission-System		ADSL1			1
+VALUE	DSL-Transmission-System		ADSL2			2
+VALUE	DSL-Transmission-System		ADSL2+		3
+VALUE	DSL-Transmission-System		VDSL1			4
+VALUE	DSL-Transmission-System		VDSL2			5
+VALUE	DSL-Transmission-System		SDSL			6
+VALUE	DSL-Transmission-System		UNKNOWN			7
+
+ATTRIBUTE	DSL-PPPOA-PPPOE-Inter-Work-Flag		183	integer
+ATTRIBUTE	DSL-Actual-Rate-Down-Factor		185	integer
+ATTRIBUTE	DSL-Combined-Line-Info			184	string
+ATTRIBUTE	Class-Volume-limit			186	string
+ATTRIBUTE	Class-Volume-In-Counter			187	string
+ATTRIBUTE	Class-Volume-Out-Counter		188	string
+ATTRIBUTE	Flow-FAC-Profile			189	string
+ATTRIBUTE	Service-Name				190	string has_tag
+ATTRIBUTE	Service-Action				191	integer has_tag
+
+VALUE	Service-Action			DE-ACTIVATE		0
+VALUE	Service-Action			ACTIVATE-WITH-ACCT	1
+VALUE	Service-Action			ACTIVATE-WITHOUT-ACCT	2
+
+ATTRIBUTE	Service-Parameter			192	string has_tag
+ATTRIBUTE	Service-Error-Cause			193	integer has_tag
+
+VALUE	Service-Error-Cause		Service-success		0
+VALUE	Service-Error-Cause		Unsupported-attribute	401
+VALUE	Service-Error-Cause		Missing-attribute	402
+VALUE	Service-Error-Cause		Invalid-request		404
+VALUE	Service-Error-Cause		Resource-unavailable	506
+VALUE	Service-Error-Cause		Generic-service-error	550
+VALUE	Service-Error-Cause		Service-not-found	551
+VALUE	Service-Error-Cause		Service-already-active	552
+VALUE	Service-Error-Cause		Service-accounting-disabled 553
+VALUE	Service-Error-Cause		Service-duplicate-parameter 554
+
+ATTRIBUTE	Deactivate-Service-Name			194	string has_tag
+ATTRIBUTE	Qos-Profile-Overhead			195	string
+ATTRIBUTE	Dynamic-QoS-Param			196	string
+ATTRIBUTE	Acct-Alt-Session-ID			197	string
+ATTRIBUTE	Idle-Timeout-Threshold			198	integer
+ATTRIBUTE	Double-Authentication			199	integer
+ATTRIBUTE	SBC-Adjacency				200	string
+ATTRIBUTE	DHCP-Field				201	octets
+ATTRIBUTE	DHCP-Option				202	octets
+ATTRIBUTE	Security-Service			203	string
+ATTRIBUTE	Reauth-Service-Name			204	string has_tag
+ATTRIBUTE	Flow-IP-Profile				205	string
+ATTRIBUTE	Radius-Throttle-Watermark		206	integer
+ATTRIBUTE	RB-IPV6-DNS				207	string
+ATTRIBUTE	RB-IPv6-Option				208	string
+ATTRIBUTE	Cluster-Partition-ID			209	string
+ATTRIBUTE	Circuit-Group-Member			210	string
+ATTRIBUTE	Delegated-Max-Prefix			212	integer
+ATTRIBUTE	IPv4-Address-Release-Control		213	string
+ATTRIBUTE	Acct-Input-IPv4-Octets			214	integer
+ATTRIBUTE	Acct-Output-IPv4-Octets			215	integer
+ATTRIBUTE	Acct-Input-IPv4-Packets			216	integer
+ATTRIBUTE	Acct-Output-IPv4-Packets		217	integer
+ATTRIBUTE	Acct-Input-IPv4-Gigawords		218	integer
+ATTRIBUTE	Acct-Output-IPv4-Gigawords		219	integer
+ATTRIBUTE	Acct-Input-IPv6-Octets			220	integer
+ATTRIBUTE	Acct-Output-IPv6-Octets			221	integer
+ATTRIBUTE	Acct-Input-IPv6-Packets			222	integer
+ATTRIBUTE	Acct-Output-IPv6-Packets		223	integer
+ATTRIBUTE	Acct-Input-IPv6-Gigawords		224	integer
+ATTRIBUTE	Acct-Output-IPv6-Gigawords		225	integer
+
+END-VENDOR	Redback

--- a/priv/dictionaries/dictionary.redback
+++ b/priv/dictionaries/dictionary.redback
@@ -177,7 +177,7 @@ ATTRIBUTE	Bind-L2TP-Flow-Control			57	integer
 ATTRIBUTE	Bind-Sub-User-At-Context		58	string
 ATTRIBUTE	Bind-Sub-Password			59	string
 ATTRIBUTE	Ip-Host-Addr				60	string
-ATTRIBUTE	IP-Tos-Field				61	integer
+ATTRIBUTE	IP-TOS-Field				61	integer
 
 VALUE	IP-TOS-Field			normal			0
 VALUE	IP-TOS-Field			min-cost-only		1

--- a/src/eradius_dict.erl
+++ b/src/eradius_dict.erl
@@ -72,7 +72,7 @@ mapfile(A) when is_atom(A) -> mapfile(atom_to_list(A));
 mapfile(A) when is_list(A) -> A ++ ".map".
 
 -spec do_load_tables(file:filename(), [table_name()]) -> ok | {error, {consult, file:filename()}}.
-do_load_tables(Dir, []) ->
+do_load_tables(_Dir, []) ->
     ok;
 do_load_tables(Dir, Tables) ->
     try

--- a/src/eradius_dict.erl
+++ b/src/eradius_dict.erl
@@ -72,17 +72,21 @@ mapfile(A) when is_atom(A) -> mapfile(atom_to_list(A));
 mapfile(A) when is_list(A) -> A ++ ".map".
 
 -spec do_load_tables(file:filename(), [table_name()]) -> ok | {error, {consult, file:filename()}}.
+do_load_tables(Dir, []) ->
+    ok;
 do_load_tables(Dir, Tables) ->
     try
-        Defs = lists:flatmap(fun (Tab) ->
+        All = lists:flatmap(fun (Tab) ->
                                      TabFile = filename:join(Dir, mapfile(Tab)),
                                      case file:consult(TabFile) of
                                          {ok, Res}       -> Res;
                                          {error, _Error} -> throw({consult, TabFile})
                                      end
                              end, Tables),
+        {MoreIncludes, Defs} = lists:partition(fun({include, _}) -> true; (_) -> false end, All),
         ets:insert(?TABLENAME, Defs),
-        lager:info("Loaded RADIUS tables: ~p", [Tables])
+        lager:info("Loaded RADIUS tables: ~p", [Tables]),
+        do_load_tables(Dir, [T || {include, T} <- MoreIncludes])
     catch
         throw:{consult, FailedTable} ->
             lager:error("Failed to load RADIUS table: ~s (wanted: ~p)", [FailedTable, Tables]),


### PR DESCRIPTION
Hello All!
Please take a look at the feature I've backported from my fork of eradius (I switched to yours and abandoned mine). This PR allows us to sync dictionaries across all consumers w/o changing anything.

For example, some RADIUS-clients parse $INCLUDE directive so one can only set /usr/share/_some_app_name_/dictionary and client library will do the rest. Unfortunately with this RADIUS-library you have to manually provide a list of dictionaries to fetch. Not anymore! Just rsync the same dictionaries, regenerate *.map and *.hrl files, recompile eradius and that's all!

I'm not expecting that you'll merge it blindly in a seconds, so any critics is more than welcome.

I have some more features in my TODO list, since I'm using dictionaries from @FreeRADIUS, but I'd like to start from something relatively simple.