### PR TITLE
Fix GOOD_CMD guard to have ability to combine it with others guards

### DIFF
--- a/src/eradius_client.erl
+++ b/src/eradius_client.erl
@@ -25,10 +25,10 @@
 -define(DEFAULT_RETRIES, 3).
 -define(DEFAULT_TIMEOUT, 5000).
 -define(RECONFIGURE_TIMEOUT, 15000).
--define(GOOD_CMD(Req), Req#radius_request.cmd == 'request' orelse
-                       Req#radius_request.cmd == 'accreq' orelse
-                       Req#radius_request.cmd == 'coareq' orelse
-                       Req#radius_request.cmd == 'discreq').
+-define(GOOD_CMD(Req), (Req#radius_request.cmd == 'request' orelse
+                        Req#radius_request.cmd == 'accreq' orelse
+                        Req#radius_request.cmd == 'coareq' orelse
+                        Req#radius_request.cmd == 'discreq')).
 
 -type nas_address() :: {inet:ip_address(), eradius_server:port_number(), eradius_lib:secret()}.
 -type options() :: [{retries, pos_integer()} |


### PR DESCRIPTION
This simple example shows the difference:

    > Cmd = 'request'.
    > IP = this_is_not_ip.
    > Cmd == 'request' orelse Cmd == 'accreq' andalso is_tuple(IP).
    true

    > (Cmd == 'request' orelse Cmd == 'accreq') andalso is_tuple(IP).
    false

This commit uses the proper priority for logical operators as in the
second example.