### PR TITLE
Resolve domain name during send request on client

### DIFF
--- a/test/eradius_client_SUITE.erl
+++ b/test/eradius_client_SUITE.erl
@@ -21,7 +21,10 @@
 -module(eradius_client_SUITE).
 -compile(export_all).
 
+-include("test/eradius_test.hrl").
+
 all() -> [
+    send_request,
     wanna_send,
     reconf_address,
     wanna_send,
@@ -41,6 +44,19 @@ end_per_suite(_Config) ->
     stopSocketCounter(),
     application:stop(eradius),
     ok.
+
+init_per_testcase(send_request, Config) ->
+    application:stop(eradius),
+    eradius_test_handler:start(),
+    Config;
+init_per_testcase(_Test, Config) ->
+    Config.
+
+end_per_testcase(send_request, Config) ->
+    eradius_test_handler:stop(),
+    Config;
+end_per_testcase(_Test, Config) ->
+    Config.
 
 %% STUFF
 
@@ -146,6 +162,13 @@ check(#state{sockets = OS, no_ports = _OP, idcounters = _OC, socket_ip = OA},
     end.
 
 %% TESTS
+
+send_request(_Config) ->
+    ?equal(accept, eradius_test_handler:send_request({127, 0, 0, 1})),
+    ?equal(accept, eradius_test_handler:send_request("127.0.0.1")),
+    ?equal(accept, eradius_test_handler:send_request("localhost")),
+    ?equal(accept, eradius_test_handler:send_request(<<"localhost">>)),
+    ok.
 
 send(FUN, Ports, Address) ->
     meckStart(),

--- a/test/eradius_test_handler.erl
+++ b/test/eradius_test_handler.erl
@@ -1,0 +1,31 @@
+-module(eradius_test_handler).
+
+-behaviour(eradius_server).
+
+-export([start/0, stop/0, send_request/1, radius_request/3]).
+
+-include("include/eradius_lib.hrl").
+
+start() ->
+    application:load(eradius),
+    application:set_env(eradius, radius_callback, ?MODULE),
+    application:set_env(eradius, client_ip, {127,0,0,1}),
+    application:set_env(eradius, session_nodes, local),
+    application:set_env(eradius, one, [{{"ONE", []}, [{"127.0.0.1", "secret"}]}]),
+    application:set_env(eradius, servers, [{one, {"127.0.0.1", [1812]}}]),
+    application:set_env(eradius, metrics, []),
+    application:ensure_all_started(eradius),
+    eradius:modules_ready([?MODULE]).
+
+stop() ->
+    application:stop(eradius),
+    application:unload(eradius),
+    application:start(eradius).
+
+send_request(IP) ->
+    {ok, R, A} = eradius_client:send_request({IP, 1812, "secret"}, #radius_request{cmd = request}, []),
+    #radius_request{cmd = Cmd} = eradius_lib:decode_request(R, <<"secret">>, A),
+    Cmd.
+
+radius_request(#radius_request{cmd = request}, _Nasprop, _Args) ->
+    {reply, #radius_request{cmd = accept}}.


### PR DESCRIPTION
A domain name will be resolved with using `inet` module. In case of
the answer has more that one IP, the IP will be selected randomly.