### PR TITLE
Version 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ eradius
 
 A generic RADIUS client and server.
 
+Version 0.9.0 - 07 Feb 2017
+---------------------------
+
+* Remove nas_prop explicit transformations in remote handler
+* Resolve domain name during send request on client, it includes the fix for pass proxy handler validation
+* Fix GOOD_CMD guard to have ability to combine it with others guards
+* Fix dictionary collisions
+
 Version 0.8.9 - 12 Dec 2017
 ---------------------------
 * Reworks dicts to maps in client and node_mon 


### PR DESCRIPTION
We bump the minor number because dictionary fix was made. There was a collision during processing dictionaries, see #130. 

Now `eradius_dict` has two version of `lookup` funciton:

```
-spec lookup(attribute_id() | value_id()) -> 
    [#attribute{} | #value{} | #vendor{}].
```

and the new helper to parametrize type:

```
-spec lookup(attribute | vendor | value, attribute_id() | value_id() | vendor_id()) -> 
    false | #attribute{} | #value{} | #vendor{}.
```

Also, since this version `eradius_client` can use domain names for destinations:

```
eradius_client:send_request({"aaa.example.com", 1812, "secret"}, #radius_request{cmd = request}, [])
```

