### PR TITLE
Set min_heap_size to default value for exometer histograms

### DIFF
--- a/include/eradius_metrics.hrl
+++ b/include/eradius_metrics.hrl
@@ -26,7 +26,8 @@
                          []}).
 
 -define(HISTOGRAM_60000, {histogram,
-                         [{slot_period, 100},
+                         [{min_heap_size, 233},
+                          {slot_period, 100},
                           {time_span, 60000}]}).
 
 -define(FUNCTION_UPTIME,{{function, eradius_metrics,


### PR DESCRIPTION
Because the default value provided by exometer is 40000 which is high
for big amount of histograms, see Feuerlabs/exometer_core#100

We set it to 233 according to default value described in Erlang Efficiency Guide.