### PR TITLE
Add dictionary unloading functionality

### DIFF
--- a/test/eradius_lib_SUITE.erl
+++ b/test/eradius_lib_SUITE.erl
@@ -64,6 +64,7 @@ init_per_testcase(Test, Config) when   Test == dec_vendor_integer_t
                                 orelse Test == vendor_attribute_id_conflict_test ->
     application:set_env(eradius, tables, [dictionary]),
     eradius_dict:start_link(),
+    eradius_dict:unload_tables([dictionary_3gpp]),
     Config;
 init_per_testcase(_, Config) -> Config.
 


### PR DESCRIPTION
Sometimes we've got a conflicting dictionaries (or just unwanted ones, or just want to test something)  within the dependency chain. Unfortunately we could not unload them before today. And we can now with this patch.

The main motivation for that functionality is to be able to use FreeRADIUS dictionaries, which have very complex include chains which in turn break eradius' test-suite (if some particular dictionary is loaded).

It's slightly different from table loading. When  you load tables you do want to walk through includes, and when you purge table you're likely don't want to.