### PR TITLE
Replace exometer with prometheus

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -1,6 +1,6 @@
 # eradius metrics
 
-`eradius` uses exometer core to implement various operation metrics. 
+`eradius` uses `prometheus.erl` to implement various operation metrics.
 For now, there are 3 groups of metrics:
 
 * `server`
@@ -15,132 +15,132 @@ By default it is `[server, nas, client]`.
 
 ### The following `server` metrics exist:
 
-_All metrics start with `[eradius, radius]` prefix and the prefix is not included into table to save space._
+_All metrics start with `eradius_radius_` prefix and the prefix is not included into table to save space._
 
-| Metric                                                                                            | Type      |
-| ------------------------------------------------------------------------------------------------- | --------- |
-| [request, invalid, server, $NAME, $IP, $PORT, total, undefined, undefined, gauge]                 | histogram |
-| [request, invalid, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]               | counter   |
-| [request, malformed, server, $NAME, $IP, $PORT, total, undefined, undefined, gauge]               | histogram |
-| [request, malformed, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]             | counter   |
-| [request, dropped, server, $NAME, $IP, $PORT, total, undefined, undefined, gauge]                 | histogram |
-| [request, dropped, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]               | counter   |
-| [request, retransmission, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]        | counter   |
-| [request, duplicate, server, $NAME, $IP, $PORT, total, undefined, undefined, gauge]               | histogram |
-| [request, duplicate, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]             | counter   |
-| [request, bad_authenticator, server, $NAME, $IP, $PORT, total, undefined, undefined, gauge] `*`   | histogram |
-| [request, bad_authenticator, server, $NAME, $IP, $PORT, total, undefined, undefined, counter] `*` | counter   | 
-| [request, unknown_type, server, $NAME, $IP, $PORT, total, undefined, undefined, gauge]            | histogram |
-| [request, unknown_type, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]          | counter   |
-| [request, total, server, $NAME, $IP, $PORT, total, undefined, undefined, gauge]                   | histogram |
-| [request, total, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]                 | counter   |
-| [request, access, server, $NAME, $IP, $PORT, total, undefined, undefined, gauge]                  | gauge     |
-| [request, access, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]                | histogram |
-| [request, accounting, server, $NAME, $IP, $PORT, total, undefined, undefined, gauge]              | histogram |
-| [request, accounting, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]            | counter   |
-| [request, coa, server, $NAME, $IP, $PORT, total, undefined, undefined, gauge]                     | histogram |
-| [request, coa, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]                   | counter   |
-| [request, disconnect, server, $NAME, $IP, $PORT, total, undefined, undefined, gauge]              | histogram |
-| [request, disconnect, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]            | counter   |
-| [response, total ,server, $NAME, $IP, $PORT, total, undefined, undefined, counter]                | counter   |
-| [response, access, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]               | counter   |
-| [response, accounting, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]           | counter   |
-| [response, access_accept, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]        | counter   |
-| [response, access_reject, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]        | counter   |
-| [response, access_challenge, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]     | counter   |
-| [response, disconnect_ack, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]       | counter   |
-| [response, disconnect_nak, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]       | counter   |
-| [response, coa_ack, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]              | counter   |
-| [response, coa_nak, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]              | counter   |
-| [request, pending, server, $NAME, $IP, $PORT, total, undefined, undefined, counter]               | counter   |
-| [time, last_request, server, $NAME, $IP, $PORT, total, undefined, undefined, ticks]               | gauge     |
-| [time, since_last_request, server, $NAME, $IP, $PORT, total, undefined, undefined, ticks]         | gauge     |
-| [time, last_reset, server, $NAME, $IP, $PORT, total, undefined, undefined, ticks]                 | gauge     |
-| [time, last_config_reset, server, $NAME, $IP, $PORT, total, undefined, undefined, ticks]          | gauge     |
-| [time, up, server, $NAME, $IP, $PORT, total, undefined, undefined, ticks]                         | gauge     |
+| Metric                                                             | Labels                  | Type      |
+| -------------------------------------------------------------------|-------------------------|-----------|
+| request_invalid_server_total_undefined_undefined_gauge             | [$NAME, $IP, $PORT]     | histogram |
+| request_invalid_server_total_undefined_undefined_counter           | [$NAME, $IP, $PORT]     | counter   |
+| request_malformed_server_total_undefined_undefined_gauge           | [$NAME, $IP, $PORT]     | histogram |
+| request_malformed_server_total_undefined_undefined_counter         | [$NAME, $IP, $PORT]     | counter   |
+| request_dropped_server_total_undefined_undefined_gauge             | [$NAME, $IP, $PORT]     | histogram |
+| request_dropped_server_total_undefined_undefined_counter           | [$NAME, $IP, $PORT]     | counter   |
+| request_retransmission_server_total_undefined_undefined_counter    | [$NAME, $IP, $PORT]     | counter   |
+| request_duplicate_server_total_undefined_undefined_gauge           | [$NAME, $IP, $PORT]     | histogram |
+| request_duplicate_server_total_undefined_undefined_counter         | [$NAME, $IP, $PORT]     | counter   |
+| request_bad_authenticator_server_total_undefined_undefined_gauge   | [$NAME, $IP, $PORT] `*` | histogram |
+| request_bad_authenticator_server_total_undefined_undefined_counter | [$NAME, $IP, $PORT] `*` | counter   |
+| request_unknown_type_server_total_undefined_undefined_gauge        | [$NAME, $IP, $PORT]     | histogram |
+| request_unknown_type_server_total_undefined_undefined_counter      | [$NAME, $IP, $PORT]     | counter   |
+| request_total_server_total_undefined_undefined_gauge               | [$NAME, $IP, $PORT]     | histogram |
+| request_total_server_total_undefined_undefined_counter             | [$NAME, $IP, $PORT]     | counter   |
+| request_access_server_total_undefined_undefined_gauge              | [$NAME, $IP, $PORT]     | gauge     |
+| request_access_server_total_undefined_undefined_counter            | [$NAME, $IP, $PORT]     | histogram |
+| request_accounting_server_total_undefined_undefined_gauge          | [$NAME, $IP, $PORT]     | histogram |
+| request_accounting_server_total_undefined_undefined_counter        | [$NAME, $IP, $PORT]     | counter   |
+| request_coa_server_total_undefined_undefined_gauge                 | [$NAME, $IP, $PORT]     | histogram |
+| request_coa_server_total_undefined_undefined_counter               | [$NAME, $IP, $PORT]     | counter   |
+| request_disconnect_server_total_undefined_undefined_gauge          | [$NAME, $IP, $PORT]     | histogram |
+| request_disconnect_server_total_undefined_undefined_counter        | [$NAME, $IP, $PORT]     | counter   |
+| response_total_server_total_undefined_undefined_counter            | [$NAME, $IP, $PORT]     | counter   |
+| response_access_server_total_undefined_undefined_counter           | [$NAME, $IP, $PORT]     | counter   |
+| response_accounting_server_total_undefined_undefined_counter       | [$NAME, $IP, $PORT]     | counter   |
+| response_access_accept_server_total_undefined_undefined_counter    | [$NAME, $IP, $PORT]     | counter   |
+| response_access_reject_server_total_undefined_undefined_counter    | [$NAME, $IP, $PORT]     | counter   |
+| response_access_challenge_server_total_undefined_undefined_counter | [$NAME, $IP, $PORT]     | counter   |
+| response_disconnect_ack_server_total_undefined_undefined_counter   | [$NAME, $IP, $PORT]     | counter   |
+| response_disconnect_nak_server_total_undefined_undefined_counter   | [$NAME, $IP, $PORT]     | counter   |
+| response_coa_ack_server_total_undefined_undefined_counter          | [$NAME, $IP, $PORT]     | counter   |
+| response_coa_nak_server_total_undefined_undefined_counter          | [$NAME, $IP, $PORT]     | counter   |
+| request_pending_server_total_undefined_undefined_counter           | [$NAME, $IP, $PORT]     | counter   |
+| time_last_request_server_total_undefined_undefined_ticks           | [$NAME, $IP, $PORT]     | gauge     |
+| time_since_last_request_server_total_undefined_undefined_ticks     | [$NAME, $IP, $PORT]     | gauge     |
+| time_last_reset_server_total_undefined_undefined_ticks             | [$NAME, $IP, $PORT]     | gauge     |
+| time_last_config_reset_server_total_undefined_undefined_ticks      | [$NAME, $IP, $PORT]     | gauge     |
+| time_up_server_total_undefined_undefined_ticks                     | [$NAME, $IP, $PORT]     | gauge     |
 
 
 `*` - these metrics exist but not been updating.
 
 ### The following `nas` metrics exist:
 
-_All metrics start with `[eradius, radius]` prefix and the prefix is not included into table to save space._
+_All metrics start with `eradius_radius_` prefix and the prefix is not included into table to save space._
 
 
-| Metric                                                                                          | Type      |
-| ----------------------------------------------------------------------------------------------- | --------- |
-| [request, dropped, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, gauge]                 | histogram |
-| [request, dropped, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]               | counter   |
-| [request, retransmission, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]        | counter   |
-| [request, duplicate, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, gauge]               | histogram |
-| [request, duplicate, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]             | counter   |
-| [request, bad_authenticator, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, gauge] `*`   | histogram |
-| [request, bad_authenticator, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter] `*` | counter   |
-| [request, unknown_type, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, gauge]            | histogram |
-| [request, unknown_type, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]          | counter   |
-| [request, total, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, gauge]                   | histogram |
-| [request, total, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]                 | counter   |
-| [request, access, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, gauge]                  | histogram |
-| [request, access, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]                | counter   |
-| [request, accounting, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, gauge]              | histogram |
-| [request, accounting, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]            | counter   |
-| [request, coa, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, gauge]                     | histogram |
-| [request, coa, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]                   | counter   |
-| [request, disconnect, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, gauge]              | histogram |
-| [request, disconnect, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]            | counter   |
-| [response, total, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]                | counter   |
-| [response, access, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]               | counter   |
-| [response, accounting, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]           | counter   |
-| [response, access_accept, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]        | counter   |
-| [response, access_reject, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]        | counter   |
-| [response, access_challenge, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]     | counter   |
-| [response, disconnect_ack, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]       | counter   |
-| [response, disconnect_nak, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]       | counter   |
-| [response, coa_ack, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]              | counter   |
-| [response, coa_nak, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]              | counter   |
-| [request, pending, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, counter]               | counter   |
-| [time, last_request, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, ticks]               | gauge     |
-| [time, since_last_request, server, $NAME, $IP, $PORT, $NASID, $NASIP, undefined, ticks]         | gauge     |
+| Metric                                             | Labels                                  | Type      |
+| ---------------------------------------------------|-----------------------------------------| --------- |
+| request_droppedserver_undefined_gauge              | [$NAME, $IP, $PORT, $NASID, $NASIP]     | histogram |
+| request_dropped_server_undefined_counter           | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| request_retransmission_server_undefined_counter    | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| request_duplicate_server_undefined_gauge           | [$NAME, $IP, $PORT, $NASID, $NASIP]     | histogram |
+| request_duplicate_server_undefined_counter         | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| request_bad_authenticator_server_undefined_gauge   | [$NAME, $IP, $PORT, $NASID, $NASIP] `*` | histogram |
+| request_bad_authenticator_server_undefined_counter | [$NAME, $IP, $PORT, $NASID, $NASIP] `*` | counter   |
+| request_unknown_type_server_undefined_gauge        | [$NAME, $IP, $PORT, $NASID, $NASIP]     | histogram |
+| request_unknown_type_server_undefined_counter      | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| request_total_server_undefined_gauge               | [$NAME, $IP, $PORT, $NASID, $NASIP]     | histogram |
+| request_total_server_undefined_counter             | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| request_access_server_undefined_gauge              | [$NAME, $IP, $PORT, $NASID, $NASIP]     | histogram |
+| request_access_server_undefined_counter            | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| request_accounting_server_undefined_gauge          | [$NAME, $IP, $PORT, $NASID, $NASIP]     | histogram |
+| request_accounting_server_undefined_counter        | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| request_coa_server_undefined_gauge                 | [$NAME, $IP, $PORT, $NASID, $NASIP]     | histogram |
+| request_coa_server_undefined_counter               | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| request_disconnect_server_undefined_gauge          | [$NAME, $IP, $PORT, $NASID, $NASIP]     | histogram |
+| request_disconnect_server_undefined_counter        | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| response_total_server_undefined_counter            | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| response_access_server_undefined_counter           | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| response_accounting_server_undefined_counter       | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| response_access_accept_server_undefined_counter    | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| response_access_reject_server_undefined_counter    | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| response_access_challenge_server_undefined_counter | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| response_disconnect_ack_server_undefined_counter   | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| response_disconnect_nak_server_undefined_counter   | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| response_coa_ack_server_undefined_counter          | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| response_coa_nak_server_undefined_counter          | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| request_pending_server_undefined_counter           | [$NAME, $IP, $PORT, $NASID, $NASIP]     | counter   |
+| time_last_request_server_undefined_ticks           | [$NAME, $IP, $PORT, $NASID, $NASIP]     | gauge     |
+| time_since_last_request_server_undefined_ticks     | [$NAME, $IP, $PORT, $NASID, $NASIP]     | gauge     |
 
 `*` - these metrics exist but not been updating.
 
 ### The following `client` metrics exist:
 
-_All metrics start with `[eradius, radius]` prefix and the prefix is not included into table to save space._
+_All metrics start with `eradius_radius_` prefix and the prefix is not included into table to save space._
 
-| Metric                                                                                          | Type      |
-| ----------------------------------------------------------------------------------------------- | --------- |
-| [request, retransmission, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, gauge]          | histogram |
-| [request, retransmission, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter]        | counter   |
-| [request, timeout, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, gauge]                 | histogram |
-| [request, timeout, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter]               | counter   |
-| [request, bad_authenticator, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter] `*` | counter   |
-| [request, malformed, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter] `*`         | counter   |
-| [request, unknown_type, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter] `*`      | counter   | 
-| [request, total, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, gauge]                   | histogram | 
-| [request, total, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter]                 | counter   |
-| [request, access, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, gauge]                  | histogram |
-| [request, access, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter]                | counter   |
-| [request, accounting, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, gauge]              | histogram |
-| [request, accounting, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter]            | counter   |
-| [request, coa, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, gauge]                     | histogram |
-| [request, coa, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter]                   | counter   |
-| [request, disconnect, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, gauge]              | histogram |
-| [request, disconnect, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter]            | counter   |
-| [response, total, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter]                | counter   |
-| [response, access, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter]               | counter   |
-| [response, accounting, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter]           | counter   |
-| [response, access_accept, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter]        | counter   |
-| [response, access_reject, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter]        | counter   |
-| [response, access_challenge, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter]     | counter   |
-| [response, dropped, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter]              | counter   |
-| [response, disconnect_ack, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter]       | counter   |
-| [response, disconnect_nak, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter]       | counter   |
-| [response, coa_ack, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter]              | counter   |
-| [response, coa_nak, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter]              | counter   |
-| [request, pending, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, counter]               | counter   |
-| [time, last_request, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, ticks]               | gauge     |
-| [time, since_last_request, client, $CNAME, $CIP, undefined, $SNAME, $SIP, $SPORT, ticks]         | gauge     |
+| Metric                                             | Labels                                    | Type      |
+| ---------------------------------------------------|-------------------------------------------|-----------|
+| request_retransmission_client_undefined_gauge      | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | histogram |
+| request_retransmission_client_undefined_counter    | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | counter   |
+| request_timeout_client_undefined_gauge             | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | histogram |
+| request_timeout_client_undefined_counter           | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | counter   |
+| request_bad_authenticator_client_undefined_counter | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT] `*` | counter   |
+| request_malformed_client_undefined_counter         | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT] `*` | counter   |
+| request_unknown_type_client_undefined_counter      | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT] `*` | counter   |
+| request_total_client_undefined_gauge               | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | histogram |
+| request_total_client_undefined_counter             | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | counter   |
+| request_access_client_undefined_gauge              | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | histogram |
+| request_access_client_undefined_counter            | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | counter   |
+| request_accounting_client_undefined_gauge          | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | histogram |
+| request_accounting_client_undefined_counter        | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | counter   |
+| request_coa_client_undefined_gauge                 | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | histogram |
+| request_coa_client_undefined_counter               | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | counter   |
+| request_disconnect_client_undefined_gauge          | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | histogram |
+| request_disconnect_client_undefined_counter        | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | counter   |
+| response_total_client_undefined_counter            | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | counter   |
+| response_access_client_undefined_counter           | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | counter   |
+| response_accounting_client_undefined_counter       | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | counter   |
+| response_access_accept_client_undefined_counter    | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | counter   |
+| response_access_reject_client_undefined_counter    | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | counter   |
+| response_access_challenge_client_undefined_counter | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | counter   |
+| response_dropped_client_undefined_counter          | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | counter   |
+| response_disconnect_ack_client_undefined_counter   | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | counter   |
+| response_disconnect_nak_client_undefined_counter   | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | counter   |
+| response_coa_ack_client_undefined_counter          | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | counter   |
+| response_coa_nak_client_undefined_counter          | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | counter   |
+| request_pending_client_undefined_counter           | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | counter   |
+| time_last_request_client_undefined_ticks           | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | gauge     |
+| time_since_last_request_client_undefined_ticks     | [$CNAME, $CIP,  $SNAME, $SIP, $SPORT]     | gauge     |
 
 `*` - these metrics exist but not been updating.
 
@@ -150,7 +150,7 @@ _All metrics start with `[eradius, radius]` prefix and the prefix is not include
         {root, {"127.0.0.1", [1812, 1813]}}
     ]}
 
-`root` will be used as a name. 
+`root` will be used as a name.
 
 `$IP` - server listener IP from configuration.
 
@@ -181,5 +181,4 @@ For "NAS2" `nas_id` will be used for `$NASID`(`name`)  `$NASIP` = "10.18.14.2".
 
 `$SPORT` - Port of destination server.
 
-Histograms are created with `slot_period` = 100 and `time_span` = 60000.
 All timing values in the histograms are in microseconds (µs).

--- a/include/eradius_metrics.hrl
+++ b/include/eradius_metrics.hrl
@@ -1,6 +1,6 @@
-%% This file contains the definitions for all metrics used by exometer.
+%% This file contains the definitions for all metrics used by prometheus.erl
 %%
-%% First the used entries and probes for exometer will be described and
+%% First the used entries and probes for prometheus will be described and
 %% then the actual metrics. These definitions contain the way metrics are
 %% exposed, e.g. for requests:
 %%
@@ -10,7 +10,7 @@
 %% In a similar way this holds for other metrics.
 
 %% this will be prepended to all eradius metrics
--define(DEFAULT_ENTRIES, [eradius, radius]).
+-define(DEFAULT_ENTRIES, <<"eradius", "_", "radius">>).
 
 %% contains all metric definitions defined below sorted by service
 -define(METRICS, [{server,  ?SERVER_METRICS},       %% metrics from all NAS together for one server socket
@@ -18,8 +18,8 @@
                   {client,  ?CLIENT_METRICS}]).     %% metrics from single client
 
 
-%% exometer basic configuration used for metrics
--define(COUNTER,        {counter,   %% exometer type
+%% prometheus basic configuration used for metrics
+-define(COUNTER,        {counter,   %% metric type
                          []}).      %% type options
 
 -define(GAUGE,          {gauge,
@@ -42,107 +42,106 @@
                          []}).
 
 -define(BASIC_TIME_METRICS, [
-     {time, last_reset, [
-       {ticks, ?GAUGE}]},
-     {time, last_config_reset, [
-       {ticks, ?GAUGE}]},
-     {time, up, [
-       {ticks, ?FUNCTION_UPTIME}]}
+     {"time", "last_reset", [
+       {"ticks", ?GAUGE}]},
+     {"time", "last_config_reset", [
+       {"ticks", ?GAUGE}]},
+     {"time", "up", [
+       {"ticks", ?FUNCTION_UPTIME}]}
      ]).
 
 -define(BASIC_REQUEST_METRICS, [
-     {request, total, [
-       {gauge, ?HISTOGRAM_60000},
-       {counter, ?COUNTER}]},
-     {request, access, [
-       {gauge, ?HISTOGRAM_60000},
-       {counter, ?COUNTER}]},
-     {request, accounting, [
-       {gauge, ?HISTOGRAM_60000},
-       {counter, ?COUNTER}]},
-     {request, coa, [
-       {gauge, ?HISTOGRAM_60000},
-       {counter, ?COUNTER}]},
-     {request, disconnect, [
-       {gauge, ?HISTOGRAM_60000},
-       {counter, ?COUNTER}]},
+     {"request", "total", [
+       {"gauge", ?HISTOGRAM_60000},
+       {"counter", ?COUNTER}]},
+     {"request", "access", [
+       {"gauge", ?HISTOGRAM_60000},
+       {"counter", ?COUNTER}]},
+     {"request", "accounting", [
+       {"gauge", ?HISTOGRAM_60000},
+       {"counter", ?COUNTER}]},
+     {"request", "coa", [
+       {"gauge", ?HISTOGRAM_60000},
+       {"counter", ?COUNTER}]},
+     {"request", "disconnect", [
+       {"gauge", ?HISTOGRAM_60000},
+       {"counter", ?COUNTER}]},
 
      %% RESPONSES
-     {response, total, [
-       {counter, ?COUNTER}]},
-     {response, access, [
-       {counter, ?COUNTER}]},
-     {response, accounting, [
-       {counter, ?COUNTER}]},
-     {response, access_accept, [
-       {counter, ?COUNTER}]},
-     {response, access_reject, [
-       {counter, ?COUNTER}]},
-     {response, access_challenge, [
-       {counter, ?COUNTER}]},
-     {response, disconnect_ack, [
-       {counter, ?COUNTER}]},
-     {response, disconnect_nak, [
-       {counter, ?COUNTER}]},
-     {response, coa_ack, [
-       {counter, ?COUNTER}]},
-     {response, coa_nak, [
-       {counter, ?COUNTER}]},
+     {"response", "total", [
+       {"counter", ?COUNTER}]},
+     {"response", "access", [
+       {"counter", ?COUNTER}]},
+     {"response", "accounting", [
+       {"counter", ?COUNTER}]},
+     {"response", "access_accept", [
+       {"counter", ?COUNTER}]},
+     {"response", "access_reject", [
+       {"counter", ?COUNTER}]},
+     {"response", "access_challenge", [
+       {"counter", ?COUNTER}]},
+     {"response", "disconnect_ack", [
+       {"counter", ?COUNTER}]},
+     {"response", "disconnect_nak", [
+       {"counter", ?COUNTER}]},
+     {"response", "coa_ack", [
+       {"counter", ?COUNTER}]},
+     {"response", "coa_nak", [
+       {"counter", ?COUNTER}]},
+     {"request", "pending", [
+       {"counter", ?COUNTER}]},
 
-     {request, pending, [
-       {gauge, ?COUNTER}]},
-
-     {time, last_request, [
-       {ticks, ?GAUGE}]},
-     {time, since_last_request, [
-       {ticks, ?FUNCTION_SINCE_LAST_REQUEST}]}
+     {"time", "last_request", [
+       {"ticks", ?GAUGE}]},
+     {"time", "since_last_request", [
+       {"ticks", ?FUNCTION_SINCE_LAST_REQUEST}]}
      ]).
 
 
 -define(SERVER_METRICS, [
-     {request, invalid, [
-       {gauge, ?HISTOGRAM_60000},
-       {counter, ?COUNTER}]},
-     {request, malformed, [
-       {gauge, ?HISTOGRAM_60000},
-       {counter, ?COUNTER}]}
+     {"request", "invalid", [
+       {"gauge", ?HISTOGRAM_60000},
+       {"counter", ?COUNTER}]},
+     {"request", "malformed", [
+       {"gauge", ?HISTOGRAM_60000},
+       {"counter", ?COUNTER}]}
      ] ++ ?NAS_METRICS
        ++ ?BASIC_TIME_METRICS).
 
 -define(NAS_METRICS, [
-     {request, dropped, [
-       {gauge, ?HISTOGRAM_60000},
-       {counter, ?COUNTER}]},
-     {request, retransmission, [
-       {gauge, ?HISTOGRAM_60000},
-       {counter, ?COUNTER}]},
-     {response, retransmission, [
-       {counter, ?COUNTER}]},
-     {request, duplicate, [
-       {gauge, ?HISTOGRAM_60000},
-       {counter, ?COUNTER}]},
-     {request, bad_authenticator, [     %TODO: this metric is just initialized and not updated within eradius
-       {gauge, ?HISTOGRAM_60000},
-       {counter, ?COUNTER}]},
-     {request, unknown_type, [
-       {gauge, ?HISTOGRAM_60000},
-       {counter, ?COUNTER}]}
+     {"request", "dropped", [
+       {"gauge", ?HISTOGRAM_60000},
+       {"counter", ?COUNTER}]},
+     {"request", "retransmission", [
+       {"gauge", ?HISTOGRAM_60000},
+       {"counter", ?COUNTER}]},
+     {"response", "retransmission", [
+       {"counter", ?COUNTER}]},
+     {"request", "duplicate", [
+       {"gauge", ?HISTOGRAM_60000},
+       {"counter", ?COUNTER}]},
+     {"request", "bad_authenticator", [     %TODO: this metric is just initialized and not updated within eradius
+       {"gauge", ?HISTOGRAM_60000},
+       {"counter", ?COUNTER}]},
+     {"request", "unknown_type", [
+       {"gauge", ?HISTOGRAM_60000},
+       {"counter", ?COUNTER}]}
      ] ++ ?BASIC_REQUEST_METRICS).
 
 
 -define(CLIENT_METRICS, [
-     {request, retransmission, [
-       {gauge, ?HISTOGRAM_60000},
-       {counter, ?COUNTER}]},
-     {request, timeout, [
-       {gauge, ?HISTOGRAM_60000},
-       {counter, ?COUNTER}]},
-     {response, bad_authenticator, [    %TODO: this metric is just initialized and not updated within eradius
-       {counter, ?COUNTER}]},
-     {response, malformed, [            %TODO: this metric is just initialized and not updated within eradius
-       {counter, ?COUNTER}]},
-     {response, unknown_type, [         %TODO: this metric is just initialized and not updated within eradius
-       {counter, ?COUNTER}]},
-     {response, dropped, [
-       {counter, ?COUNTER}]}
+     {"request", "retransmission", [
+       {"gauge", ?HISTOGRAM_60000},
+       {"counter", ?COUNTER}]},
+     {"request", "timeout", [
+       {"gauge", ?HISTOGRAM_60000},
+       {"counter", ?COUNTER}]},
+     {"response", "bad_authenticator", [    %TODO: this metric is just initialized and not updated within eradius
+       {"counter", ?COUNTER}]},
+     {"response", "malformed", [            %TODO: this metric is just initialized and not updated within eradius
+       {"counter", ?COUNTER}]},
+     {"response", "unknown_type", [         %TODO: this metric is just initialized and not updated within eradius
+       {"counter", ?COUNTER}]},
+     {"response", "dropped", [
+       {"counter", ?COUNTER}]}
      ] ++ ?BASIC_REQUEST_METRICS).

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,6 @@
 
 {deps, [
 	{stacktrace_compat, "1.0.2"},
-	{exometer_core,  "1.5.7"},
 	{prometheus, "4.6.0"}
 ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,8 @@
 
 {deps, [
 	{stacktrace_compat, "1.0.2"},
-	{exometer_core,  "1.5.7"}
+	{exometer_core,  "1.5.7"},
+	{prometheus, "4.6.0"}
 ]}.
 
 {pre_hooks, [{compile, "escript dicts_compiler.erl compile"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,20 +1,8 @@
 {"1.1.0",
-[{<<"bear">>,{pkg,<<"bear">>,<<"0.8.7">>},2},
- {<<"exometer_core">>,{pkg,<<"exometer_core">>,<<"1.5.7">>},0},
- {<<"folsom">>,{pkg,<<"folsom">>,<<"0.8.7">>},1},
- {<<"hut">>,{pkg,<<"hut">>,<<"1.2.1">>},1},
- {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.0">>},1},
- {<<"prometheus">>,{pkg,<<"prometheus">>,<<"4.6.0">>},0},
- {<<"setup">>,{pkg,<<"setup">>,<<"2.0.2">>},1},
+[{<<"prometheus">>,{pkg,<<"prometheus">>,<<"4.6.0">>},0},
  {<<"stacktrace_compat">>,{pkg,<<"stacktrace_compat">>,<<"1.0.2">>},0}]}.
 [
 {pkg_hash,[
- {<<"bear">>, <<"16264309AE5D005D03718A5C82641FCC259C9E8F09ADEB6FD79CA4271168656F">>},
- {<<"exometer_core">>, <<"AB97E34A5D69AB14E6AE161DB4CCA5B5E655E635B842F830EE6AB2CBFCFDC30A">>},
- {<<"folsom">>, <<"A885F0AEEE4C84270954C88A55A5A473D6B2C7493E32FFDC5765412DD555A951">>},
- {<<"hut">>, <<"08D46679523043424870723923971889E8A34D63B2F946A35B46CF921D1236E7">>},
- {<<"parse_trans">>, <<"09765507A3C7590A784615CFD421D101AEC25098D50B89D7AA1D66646BC571C1">>},
  {<<"prometheus">>, <<"20510F381DB1CCAB818B4CF2FAC5FA6AB5CC91BC364A154399901C001465F46F">>},
- {<<"setup">>, <<"1203F4CDA11306C2E34434244576DED0A7BBFB0908D9A572356C809BD0CDF085">>},
  {<<"stacktrace_compat">>, <<"8AD31C32C9A0EADB1EB298F04DC8B0C8D79BCC6233A638B02791FFCA4F331275">>}]}
 ].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,20 @@
+{"1.1.0",
+[{<<"bear">>,{pkg,<<"bear">>,<<"0.8.7">>},2},
+ {<<"exometer_core">>,{pkg,<<"exometer_core">>,<<"1.5.7">>},0},
+ {<<"folsom">>,{pkg,<<"folsom">>,<<"0.8.7">>},1},
+ {<<"hut">>,{pkg,<<"hut">>,<<"1.2.1">>},1},
+ {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.0">>},1},
+ {<<"prometheus">>,{pkg,<<"prometheus">>,<<"4.6.0">>},0},
+ {<<"setup">>,{pkg,<<"setup">>,<<"2.0.2">>},1},
+ {<<"stacktrace_compat">>,{pkg,<<"stacktrace_compat">>,<<"1.0.2">>},0}]}.
+[
+{pkg_hash,[
+ {<<"bear">>, <<"16264309AE5D005D03718A5C82641FCC259C9E8F09ADEB6FD79CA4271168656F">>},
+ {<<"exometer_core">>, <<"AB97E34A5D69AB14E6AE161DB4CCA5B5E655E635B842F830EE6AB2CBFCFDC30A">>},
+ {<<"folsom">>, <<"A885F0AEEE4C84270954C88A55A5A473D6B2C7493E32FFDC5765412DD555A951">>},
+ {<<"hut">>, <<"08D46679523043424870723923971889E8A34D63B2F946A35B46CF921D1236E7">>},
+ {<<"parse_trans">>, <<"09765507A3C7590A784615CFD421D101AEC25098D50B89D7AA1D66646BC571C1">>},
+ {<<"prometheus">>, <<"20510F381DB1CCAB818B4CF2FAC5FA6AB5CC91BC364A154399901C001465F46F">>},
+ {<<"setup">>, <<"1203F4CDA11306C2E34434244576DED0A7BBFB0908D9A572356C809BD0CDF085">>},
+ {<<"stacktrace_compat">>, <<"8AD31C32C9A0EADB1EB298F04DC8B0C8D79BCC6233A638B02791FFCA4F331275">>}]}
+].

--- a/src/eradius.app.src
+++ b/src/eradius.app.src
@@ -3,7 +3,7 @@
    {description, "Erlang RADIUS server"},
    {vsn, git},
    {registered, [eradius_dict, eradius_sup, eradius_server_top_sup, eradius_server_sup, eradius_server_mon]},
-   {applications, [kernel, stdlib, crypto, exometer_core]},
+   {applications, [kernel, stdlib, crypto, prometheus]},
    {mod, {eradius, []}},
    {env, [
       {servers, []},

--- a/src/eradius_client.erl
+++ b/src/eradius_client.erl
@@ -177,41 +177,41 @@ send_request_loop(Socket, SMon, Peer = {_ServerName, {IP, Port}}, ReqId, Authent
 
 % @private
 update_client_request(request, MetricsInfo, Ms) ->
-    eradius_metrics:update_client_request(access, MetricsInfo, Ms);
+    eradius_metrics:update_client_request("access", MetricsInfo, Ms);
 update_client_request(accreq, MetricsInfo, Ms) ->
-    eradius_metrics:update_client_request(accounting, MetricsInfo, Ms);
+    eradius_metrics:update_client_request("accounting", MetricsInfo, Ms);
 update_client_request(coareq, MetricsInfo, Ms) ->
-    eradius_metrics:update_client_request(coa, MetricsInfo, Ms);
+    eradius_metrics:update_client_request("coa", MetricsInfo, Ms);
 update_client_request(discreq, MetricsInfo, Ms) ->
-    eradius_metrics:update_client_request(disconnect, MetricsInfo, Ms);
+    eradius_metrics:update_client_request("disconnect", MetricsInfo, Ms);
 update_client_request(retransmission, MetricsInfo, Ms) ->
-    eradius_metrics:update_client_request(retransmission, MetricsInfo, Ms);
+    eradius_metrics:update_client_request("retransmission", MetricsInfo, Ms);
 update_client_request(pending, MetricsInfo, Pending) ->
-    eradius_metrics:update_client_request(pending, MetricsInfo, Pending);
+    eradius_metrics:update_client_request("pending", MetricsInfo, Pending);
 update_client_request(timeout, MetricsInfo, Ms) ->
-    eradius_metrics:update_client_request(timeout, MetricsInfo, Ms);
+    eradius_metrics:update_client_request("timeout", MetricsInfo, Ms);
 update_client_request(_, _, _) ->
     ok.
 
 %% @private
 update_client_response(accept, MetricsInfo) ->
-    eradius_metrics:update_client_response(access_accept, MetricsInfo);
+    eradius_metrics:update_client_response("access_accept", MetricsInfo);
 update_client_response(reject, MetricsInfo) ->
-    eradius_metrics:update_client_response(access_reject, MetricsInfo);
+    eradius_metrics:update_client_response("access_reject", MetricsInfo);
 update_client_response(challenge, MetricsInfo) ->
-    eradius_metrics:update_client_response(access_challenge, MetricsInfo);
+    eradius_metrics:update_client_response("access_challenge", MetricsInfo);
 update_client_response(accresp, MetricsInfo) ->
-    eradius_metrics:update_client_response(accounting, MetricsInfo);
+    eradius_metrics:update_client_response("accounting", MetricsInfo);
 update_client_response(coanak, MetricsInfo) ->
-    eradius_metrics:update_client_response(coa_nak, MetricsInfo);
+    eradius_metrics:update_client_response("coa_nak", MetricsInfo);
 update_client_response(coaack, MetricsInfo) ->
-    eradius_metrics:update_client_response(coa_ack, MetricsInfo);
+    eradius_metrics:update_client_response("coa_ack", MetricsInfo);
 update_client_response(discnak, MetricsInfo) ->
-    eradius_metrics:update_client_response(disconnect_nak, MetricsInfo);
+    eradius_metrics:update_client_response("disconnect_nak", MetricsInfo);
 update_client_response(discack, MetricsInfo) ->
-    eradius_metrics:update_client_response(disconnect_ack, MetricsInfo);
+    eradius_metrics:update_client_response("disconnect_ack", MetricsInfo);
 update_client_response(dropped, MetricsInfo) ->
-    eradius_metrics:update_client_response(dropped, MetricsInfo);
+    eradius_metrics:update_client_response("dropped", MetricsInfo);
 update_client_response(_, _) ->
     ok.
 

--- a/src/eradius_metrics.erl
+++ b/src/eradius_metrics.erl
@@ -45,54 +45,54 @@ delete_client({{CName, CIP, undefined}, {SName, SIP, SPort}}) ->
 %% API for metric updates.
 %% -------------------------------------------------------
 -spec update_server_request(atom(), atom_address(), integer()) -> any().
-update_server_request(pending, Address, Pending) ->
-    update_request(server, pending, Address, Pending);
+update_server_request("pending", Address, Pending) ->
+    update_request(server, "pending", Address, Pending);
 update_server_request(Type, Address, Ms) ->
-    [update_request(server, ReqType, Address, Ms) || ReqType <- [Type, total]],
-    update_server_time(last_request, Address).
+    [update_request(server, ReqType, Address, Ms) || ReqType <- [Type, "total"]],
+    update_server_time("last_request", Address).
 
 -spec update_server_response(atom(), atom_address()) -> any().
 update_server_response(Type, Address) ->
-    [update_response(server, ReqType, Address) || ReqType <- [Type, total]].
+    [update_response(server, ReqType, Address) || ReqType <- [Type, "total"]].
 
 -spec update_server_time(last_reset | last_config_reset | last_request, atom_address()) -> any().
 update_server_time(Type, Address) ->
     update_time(server, Type, Address).
 
 -spec update_nas_request(atom(), atom_address_pair(), integer()) -> any().
-update_nas_request(pending, {ServerAddress = {SName, SIP, SPort}, {NID, NIP, _NPort}}, Pending) ->
-    update_server_request(pending, ServerAddress, Pending),
-    update_request(nas, pending, {SName, SIP, SPort, NID, NIP}, Pending);
+update_nas_request("pending", {ServerAddress = {SName, SIP, SPort}, {NID, NIP, _NPort}}, Pending) ->
+    update_server_request("pending", ServerAddress, Pending),
+    update_request(nas, "pending", {SName, SIP, SPort, NID, NIP}, Pending);
 update_nas_request(Type, MetricsInfo = {ServerAddress = {SName, SIP, SPort}, {NID, NIP, _NPort}}, Ms) ->
     update_server_request(Type, ServerAddress, Ms),
-    [update_request(nas, ReqType, {SName, SIP, SPort, NID, NIP}, Ms) || ReqType <- [Type, total]],
+    [update_request(nas, ReqType, {SName, SIP, SPort, NID, NIP}, Ms) || ReqType <- [Type, "total"]],
     update_nas_time(last_request, MetricsInfo).
 
 -spec update_nas_response(atom(), atom_address_pair()) -> any().
 update_nas_response(Type, {ServerAddress = {SName, SIP, SPort}, {NID, NIP, _NPort}}) ->
     update_server_response(Type, ServerAddress),
-    [update_response(nas, ReqType, {SName, SIP, SPort, NID, NIP}) || ReqType <- [Type, total]].
+    [update_response(nas, ReqType, {SName, SIP, SPort, NID, NIP}) || ReqType <- [Type, "total"]].
 
 -spec update_nas_time(last_request, atom_address_pair()) -> any().
 update_nas_time(last_request, {{SName, SIP, SPort}, {NID, NIP, _NPort}}) ->
-    update_time(nas, last_request, {SName, SIP, SPort, NID, NIP}).
+    update_time(nas, "last_request", {SName, SIP, SPort, NID, NIP}).
 
 -spec update_client_request(atom(), atom_address_pair(), integer()) -> any().
-update_client_request(pending, {{CName, CIP, undefined}, {SName, SIP, SPort}}, Pending) ->
-    update_request(client, pending, {CName, CIP, SName, SIP, SPort}, Pending);
-update_client_request(retransmission, {{CName, CIP, undefined}, {SName, SIP, SPort}}, Ms) ->
-    update_request(client, retransmission, {CName, CIP, SName, SIP, SPort}, Ms);
+update_client_request("pending", {{CName, CIP, undefined}, {SName, SIP, SPort}}, Pending) ->
+    update_request(client, "pending", {CName, CIP, SName, SIP, SPort}, Pending);
+update_client_request("retransmission", {{CName, CIP, undefined}, {SName, SIP, SPort}}, Ms) ->
+    update_request(client, "retransmission", {CName, CIP, SName, SIP, SPort}, Ms);
 update_client_request(Type, MetricsInfo = {{CName, CIP, undefined}, {SName, SIP, SPort}}, Ms) ->
-    [update_request(client, ReqType, {CName, CIP, SName, SIP, SPort}, Ms) || ReqType <- [Type, total]],
+    [update_request(client, ReqType, {CName, CIP, SName, SIP, SPort}, Ms) || ReqType <- [Type, "total"]],
     update_client_time(last_request, MetricsInfo).
 
 -spec update_client_response(atom(), atom_address_pair()) -> any().
 update_client_response(Type, {{CName, CIP, undefined}, {SName, SIP, SPort}}) ->
-    [update_response(client, ReqType, {CName, CIP, SName, SIP, SPort}) || ReqType <- [Type, total]].
+    [update_response(client, ReqType, {CName, CIP, SName, SIP, SPort}) || ReqType <- [Type, "total"]].
 
 -spec update_client_time(last_request, atom_address_pair()) -> any().
 update_client_time(last_request, {{CName, CIP, undefined}, {SName, SIP, SPort}}) ->
-    update_time(client, last_request, {CName, CIP, SName, SIP, SPort}).
+    update_time(client, "last_request", {CName, CIP, SName, SIP, SPort}).
 
 -spec make_addr_info({term(), {inet:ip_address(), integer()}}) -> atom_address().
 make_addr_info({undefined, {IP, Port}}) ->
@@ -129,34 +129,52 @@ proceed_metrics_action(Action, Service, Args, Metrics) ->
     lists:foreach(
         fun({MetricName, MetricType, Units}) ->
             lists:foreach(
-                fun({UnitType, {ExoType, ExoTypeOpts}}) ->
-                    PartId = case Service of
-                                      server    -> server_layout(Args);
-                                      nas       -> nas_layout(Args);
-                                      client    -> client_layout(Args)
-                                  end,
-                    %% this is the final exometer id:
-                    FinalId = lists:append([?DEFAULT_ENTRIES, [MetricName, MetricType], PartId, [UnitType]]),
+                fun({UnitType, {ExoType, _ExoTypeOpts}}) ->
+                    {PartId, Labels, _} = case Service of
+                                              server    -> server_layout(Args);
+                                              nas       -> nas_layout(Args);
+                                              client    -> client_layout(Args)
+                                          end,
+
+                    %% this is the final id of the metric
+                    FinalId = list_to_binary([?DEFAULT_ENTRIES, "_", MetricName, "_", MetricType, "_", PartId, "_", UnitType]),
                     case Action of
-                        create ->
-                            case ExoType of
-                                {function,_,_,_,_,_} ->
-                                    % functions are tricky, they need further arguments and
-                                    % will not be initialized at start
-                                    try % exometer crashes if two identical ids are created
-                                        ExoType1 = setelement(4, ExoType, [Service, Args]),
-                                        exometer:new(FinalId, ExoType1, ExoTypeOpts)
-                                    catch
-                                        _:_ -> ok
-                                    end;
-                                _ ->
-                                    exometer:update_or_create(FinalId, 0, ExoType, ExoTypeOpts)
-                            end;
-                        delete ->
-                            exometer:delete(FinalId)
+                      create ->
+                        case ExoType of
+                          {function,_,_,_,_,_} ->
+                            try
+                              MetricCb = element(3, ExoType),
+                              prometheus_gauge:declare([{name, FinalId}, {help, ""}, {labels, Labels}]),
+                              % update UpTime metric each 5000 seconds
+                              timer:apply_interval(5000, ?MODULE, MetricCb, [Service, Args])
+                              catch _:_ -> ok
+                              end;
+                          _ ->
+                            create_metric(FinalId, Labels, ExoType)
+                          end;
+                      delete ->
+                        delete_metric(FinalId, Labels, ExoType)
                     end
                 end, Units)
         end, Metrics).
+
+create_metric(Name, Labels, counter) ->
+    prometheus_counter:declare([{name, Name}, {help, ""}, {labels, Labels}]);
+create_metric(Name, Labels, histogram) ->
+    prometheus_histogram:declare([{name, Name}, {help, ""}, {labels, Labels}, {buckets, [10, 30, 50, 75, 100, 1000, 2000]}]);
+create_metric(Name, Labels, gauge) ->
+    prometheus_gauge:declare([{name, Name}, {help, ""}, {labels, Labels}]);
+create_metric(_, _, _) ->
+    ok.
+
+delete_metric(Name, Labels, counter) ->
+    prometheus_counter:remove(Name, Labels);
+delete_metric(Name, Labels, histogram) ->
+    prometheus_histogram:remove(Name, Labels);
+delete_metric(Name, Labels, gauge) ->
+    prometheus_gauge:remove(Name, Labels);
+delete_metric(_, _, _) ->
+    ok.
 
 update_request(server, Type, Args, Ms) ->
     Args1 = server_layout(Args),
@@ -191,29 +209,69 @@ update_time(client, Type, Args) ->
     Args1 = client_layout(Args),
     update_exo_time(Type, Args1, Sec).
 
-update_exo_request(pending, Args, Value) ->
-    PartId = lists:append([?DEFAULT_ENTRIES, [request, pending], Args]),
-    exometer:update(PartId ++ [gauge], Value);
-update_exo_request(Type, Args, Ms) ->
-    PartId = lists:append([?DEFAULT_ENTRIES, [request, Type], Args]),
-    exometer:update(PartId ++ [counter], 1),
-    exometer:update(PartId ++ [gauge], Ms).
+update_exo_request("pending", {Args, _, Labels}, Value) ->
+    Id = list_to_binary([?DEFAULT_ENTRIES, "_", "request", "_", "pending", "_", Args, "_counter"]),
+    try
+        if Value < 0 ->
+                prometheus_gauge:dec(Id, Labels);
+           true ->
+                prometheus_gauge:inc(Id, Labels)
+        end
+    catch _:_ ->
+            undefined
+    end;
 
-update_exo_request(Type, Args) ->
-    PartId = lists:append([?DEFAULT_ENTRIES, [response, Type], Args]),
-    exometer:update(PartId ++ [counter], 1).
+update_exo_request(Type, {Args, _, Labels}, Ms) ->
+    IdCounter = list_to_binary([?DEFAULT_ENTRIES, "_", "request", "_", Type, "_", Args, "_counter"]),
+    IdHistogram = list_to_binary([?DEFAULT_ENTRIES, "_", "request", "_", Type, "_", Args, "_gauge"]),
+    try
+        prometheus_histogram:observe(IdHistogram, Labels, Ms),
+        prometheus_counter:inc(IdCounter, Labels)
+    catch _:_ ->
+            undefined
+    end.
 
-update_exo_time(Type, Args, Sec) ->
-    PartId = lists:append([?DEFAULT_ENTRIES, [time, Type], Args]),
-    exometer:update(PartId ++ [ticks], Sec).
+update_exo_request(Type, {Args, _, Labels}) ->
+    Id = list_to_binary([?DEFAULT_ENTRIES, "_", "response", "_", Type, "_", Args, "_counter"]),
+    try
+        prometheus_counter:inc(Id, Labels)
+    catch _:_ ->
+            undefined
+    end.
 
-%% exometer id layouts for generic parts of the exometer id
+update_exo_time(Type, {Args, _, Labels}, Sec) ->
+    Id = list_to_binary([?DEFAULT_ENTRIES, "_", "time", "_", Type, "_", Args, "_ticks"]),
+    try
+        prometheus_gauge:set(Id, Labels, Sec)
+    catch _:_ ->
+        undefined
+    end.
+
 server_layout({ServerName, ServerIP, ServerPort}) ->
-    [server, ServerName, ServerIP, ServerPort, total, undefined, undefined].
+    Server = atom_to_list(ServerName),
+    IP = string:join(string:replace(atom_to_list(ServerIP), ".", "_", all), ""),
+    Port = atom_to_list(ServerPort),
+    {list_to_binary(["server", "_", "total", "_", "undefined", "_", "undefined"]),
+     [server_name, server_ip, server_port],
+     [Server, IP, Port]}.
 nas_layout({ServerName, ServerIP, ServerPort, NasId, NasIP}) ->
-    [server, ServerName, ServerIP, ServerPort, NasId, NasIP, undefined].
+    Server = atom_to_list(ServerName),
+    IP = string:join(string:replace(atom_to_list(ServerIP), ".", "_", all), ""),
+    Port = atom_to_list(ServerPort),
+    NasIdList = string:join(string:replace(atom_to_list(NasId), ".", "_", all), ""),
+    NasIPList = string:join(string:replace(atom_to_list(NasIP), ".", "_", all), ""),
+    {list_to_binary(["server", "_", "undefined"]),
+     [server_name, server_ip, server_port, nas_id, nas_ip],
+     [Server, IP, Port, NasIdList, NasIPList]}.
 client_layout({ClientName, ClientIP, ServerName, ServerIP, ServerPort}) ->
-    [client, ClientName, ClientIP, undefined, ServerName, ServerIP, ServerPort].
+    Client = atom_to_list(ClientName),
+    CIP = string:join(string:replace(atom_to_list(ClientIP), ".", "_", all), ""),
+    Server = string:join(string:replace(atom_to_list(ServerName), ".", "_", all), ""),
+    SIP = string:join(string:replace(atom_to_list(ServerIP), ".", "_", all), ""),
+    SPort = atom_to_list(ServerPort),
+    {list_to_binary(["client", "_", "undefined"]),
+     [client_name, client_ip, server_name, server_ip, server_port],
+     [Client, CIP, Server, SIP, SPort]}.
 
 to_atom(Value) when is_atom(Value) -> Value;
 to_atom(Value) when is_binary(Value) -> binary_to_atom(Value, latin1);
@@ -236,17 +294,28 @@ port_to_atom(Port) when is_atom(Port) -> Port;
 port_to_atom(Port) -> list_to_atom(integer_to_list(Port)).
 
 update_uptime(server, ServerAddress) ->
-    Args = server_layout(ServerAddress),
-    LastResetId = lists:append([?DEFAULT_ENTRIES, [time, last_reset], Args, [ticks]]),
-    {ok, [{ms_since_reset, Uptime}]} = exometer:get_value(LastResetId, ms_since_reset),
-    [{value, round(Uptime)}].
+    {Args, _, Labels} = server_layout(ServerAddress),
+    LastResetId = list_to_binary([?DEFAULT_ENTRIES, "_", "time", "_", "last_reset", "_", Args, "_", "ticks"]),
+    try
+        LastReset = prometheus_gauge:value(LastResetId, Labels),
+        Uptime = round(timestamp(milli_seconds) - LastReset),
+        prometheus_gauge:set(list_to_binary([?DEFAULT_ENTRIES, "_", "time", "_", "up", "_", Args, "_", "ticks"]), Labels, Uptime)
+    catch _:_ ->
+            undefined
+    end.
 
 update_since_last_request(Service, Address) ->
-    Args = case Service of
-               server    -> server_layout(Address);
-               nas       -> nas_layout(Address);
-               client    -> client_layout(Address)
-           end,
-    LastRequestId = lists:append([?DEFAULT_ENTRIES, [time, last_request], Args, [ticks]]),
-    {ok, [{value, LastRequestTs}]} = exometer:get_value(LastRequestId, value),
-    [{value, round(timestamp(milli_seconds) - LastRequestTs)}].
+    {Args, _, Labels} = case Service of
+                            server    -> server_layout(Address);
+                            nas       -> nas_layout(Address);
+                            client    -> client_layout(Address)
+                     end,
+    LastRequestId = list_to_binary([?DEFAULT_ENTRIES, "_", "time", "_", "last_request", "_", Args, "_", "ticks"]),
+    try
+        LastRequestTs = prometheus_gauge:value(LastRequestId, Labels),
+        NewValue = round(timestamp(milli_seconds) - LastRequestTs),
+        prometheus_gauge:set(list_to_binary([?DEFAULT_ENTRIES, "_", "time", "_", "since_last_request", "_", Args, "_", "ticks"]),
+                             Labels, NewValue)
+    catch _:_ ->
+            undefined
+    end.

--- a/src/eradius_proxy.erl
+++ b/src/eradius_proxy.erl
@@ -221,4 +221,3 @@ strip(Username, prefix, true, Separator) ->
 %	    MetricName = eradius_metrics:get_metric_name(IP, Port, routes_resolved, proxy),
 %	    exometer:update_or_create(MetricName, 1, spiral, [{time_span, 1000}])
 %    end.
-

--- a/src/eradius_server_mon.erl
+++ b/src/eradius_server_mon.erl
@@ -161,13 +161,13 @@ update_nases(ToDelete, ToInsert) ->
                       NasProp = Nas#nas.prop,
                       MetricsInfo = {ServerAddr, _} = NasProp#nas_prop.metrics_info,
                       eradius_metrics:delete_nas(MetricsInfo),
-                      eradius_metrics:update_server_time(config_reset, ServerAddr)
+                      eradius_metrics:update_server_time("last_config_reset", ServerAddr)
                   end, ToDelete),
     lists:foreach(fun(Nas) ->
                       ets:insert(?NAS_TAB, Nas),
                       NasProp = Nas#nas.prop,
                       MetricsInfo = {ServerAddr, _} = NasProp#nas_prop.metrics_info,
                       eradius_metrics:create_nas(MetricsInfo),
-                      eradius_metrics:update_server_time(config_reset, ServerAddr)
+                      eradius_metrics:update_server_time("last_config_reset", ServerAddr)
                   end, ToInsert).
 

--- a/test/eradius_metrics_SUITE.erl
+++ b/test/eradius_metrics_SUITE.erl
@@ -30,14 +30,15 @@
 -define(ATTRS_BAD, [{?NAS_Identifier, "bad"}]).
 -define(ATTRS_ERROR, [{?NAS_Identifier, "error"}]).
 -define(LOCALHOST, eradius_test_handler:localhost(atom)).
--define(CLIENT_ID_FORMAT_GOOD(Name, Type, Unit), [eradius, radius, Name, Type, client, test, '127.0.0.2', undefined, good, eradius_test_handler:localhost(atom), '1812', Unit]).
--define(CLIENT_ID_FORMAT_BAD(Name, Type, Unit), [eradius, radius, Name, Type, client, test, '127.0.0.2', undefined, bad, eradius_test_handler:localhost(atom), '1813', Unit]).
--define(CLIENT_ID_FORMAT_ERROR(Name, Type, Unit), [eradius, radius, Name, Type, client, test, '127.0.0.2', undefined, error, eradius_test_handler:localhost(atom), '1814', Unit]).
--define(SERVER_ID_FORMAT_GOOD(Name, Type, Unit), [eradius, radius, Name, Type, server, good, eradius_test_handler:localhost(atom), '1812', good_nas, '127.0.0.2', undefined, Unit]).
--define(SERVER_ID_FORMAT_GOOD_TOTAL(Name, Type, Unit), [eradius, radius, Name, Type, server, good, eradius_test_handler:localhost(atom), '1812', total, undefined, undefined, Unit]).
--define(SERVER_ID_FORMAT_BAD(Name, Type, Unit), [eradius, radius, Name, Type, server, bad, eradius_test_handler:localhost(atom), '1813', bad_nas, '127.0.0.2', undefined, Unit]).
--define(SERVER_ID_FORMAT_BAD_TOTAL(Name, Type, Unit), [eradius, radius, Name, Type, server, bad, eradius_test_handler:localhost(atom), '1813', total, undefined, undefined, Unit]).
--define(SERVER_ID_FORMAT_ERROR(Name, Type, Unit), [eradius, radius, Name, Type, server, error, eradius_test_handler:localhost(atom), '1814', error_nas, '127.0.0.2', undefined, Unit]).
+
+-define(CLIENT_ID_FORMAT_GOOD(Name, Type, Unit), list_to_binary(["eradius_radius_", Name, "_", Type, "_client_undefined_", Unit])).
+-define(CLIENT_ID_FORMAT_BAD(Name, Type, Unit), list_to_binary(["eradius_radius_", Name, "_", Type, "_client_undefined_", Unit])).
+-define(CLIENT_ID_FORMAT_ERROR(Name, Type, Unit), list_to_binary(["eradius_radius_", Name, "_", Type, "_client_undefined_", Unit])).
+-define(SERVER_ID_FORMAT_GOOD(Name, Type, Unit), list_to_binary(["eradius_radius_", Name, "_", Type, "_server_undefined_", Unit])).
+-define(SERVER_ID_FORMAT_GOOD_TOTAL(Name, Type, Unit), list_to_binary(["eradius_radius_", Name, "_", Type, "_server_total_undefined_undefined_", Unit])).
+-define(SERVER_ID_FORMAT_BAD(Name, Type, Unit), list_to_binary(["eradius_radius_", Name,  "_", Type, "_server_undefined_", Unit])).
+-define(SERVER_ID_FORMAT_BAD_TOTAL(Name, Type, Unit), list_to_binary(["eradius_radius_", Name, "_", Type, "_server_total_undefined_undefined_", Unit])).
+-define(SERVER_ID_FORMAT_ERROR(Name, Type, Unit), list_to_binary(["eradius_radius_", Name, "_", Type, "_server_undefined_", Unit])).
 
 
 %% test callbacks
@@ -100,50 +101,95 @@ bad_requests(_Config) ->
 error_requests(_Config) ->
     check_single_request(error, request, access, access_accept).
 
-
 %% helpers
 check_single_request(good, EradiusRequestType, RequestType, ResponseType) ->
     ok = send_request(EradiusRequestType, eradius_test_handler:localhost(tuple), 1812, ?ATTRS_GOOD, [{server_name, good}, {client_name, test}]),
-    ok = check_metric(?CLIENT_ID_FORMAT_GOOD(request, RequestType, counter), 1),
-    ok = check_metric(?CLIENT_ID_FORMAT_GOOD(response, ResponseType, counter), 1),
-    ok = check_metric(?SERVER_ID_FORMAT_GOOD(request, RequestType, counter), 1),
-    ok = check_metric(?SERVER_ID_FORMAT_GOOD(response, ResponseType, counter), 1),
-    ok = check_metric(?SERVER_ID_FORMAT_GOOD_TOTAL(request, RequestType, counter), 1),
-    ok = check_metric(?SERVER_ID_FORMAT_GOOD_TOTAL(response, ResponseType, counter), 1);
+    ok = check_metric(?CLIENT_ID_FORMAT_GOOD("request", atom_to_list(RequestType), "counter"),
+                      ["test", "127_0_0_2", "good", eradius_test_handler:localhost(atom), "1812"],
+                      1),
+    ok = check_metric(?CLIENT_ID_FORMAT_GOOD("response", atom_to_list(ResponseType), "counter"),
+                      ["test", "127_0_0_2", "good", eradius_test_handler:localhost(atom), "1812"],
+                      1),
+    ok = check_metric(?SERVER_ID_FORMAT_GOOD("request", atom_to_list(RequestType), "counter"),
+                      ["good", eradius_test_handler:localhost(atom), "1812", "good_nas", "127_0_0_2"],
+                      1),
+    ok = check_metric(?SERVER_ID_FORMAT_GOOD("response", atom_to_list(ResponseType), "counter"),
+                      ["good", eradius_test_handler:localhost(atom), "1812", "good_nas", "127_0_0_2"],
+                      1),
+    ok = check_metric(?SERVER_ID_FORMAT_GOOD_TOTAL("request", atom_to_list(RequestType), "counter"),
+                      ["good", eradius_test_handler:localhost(atom), "1812"],
+                      1),
+    ok = check_metric(?SERVER_ID_FORMAT_GOOD_TOTAL("response", atom_to_list(ResponseType), "counter"),
+                      ["good", eradius_test_handler:localhost(atom), "1812"],
+                      1);
 check_single_request(bad, EradiusRequestType, RequestType, ResponseType) ->
     ok = send_request(EradiusRequestType, eradius_test_handler:localhost(tuple), 1813, ?ATTRS_BAD, [{server_name, bad}, {client_name, test}]),
-    ok = check_metric(?CLIENT_ID_FORMAT_BAD(request, RequestType, counter), 1),
-    ok = check_metric(?CLIENT_ID_FORMAT_BAD(response, ResponseType, counter), 1),
-    ok = check_metric(?SERVER_ID_FORMAT_BAD(request, RequestType, counter), 1),
-    ok = check_metric(?SERVER_ID_FORMAT_BAD(response, ResponseType, counter), 1),
-    ok = check_metric(?SERVER_ID_FORMAT_BAD_TOTAL(request, RequestType, counter), 1),
-    ok = check_metric(?SERVER_ID_FORMAT_BAD_TOTAL(response, ResponseType, counter), 1);
+    ok = check_metric(?CLIENT_ID_FORMAT_BAD("request", atom_to_list(RequestType), "counter"),
+                      ["test", "127_0_0_2", "bad", eradius_test_handler:localhost(atom), "1813"],
+                      1),
+    ok = check_metric(?CLIENT_ID_FORMAT_BAD("response", atom_to_list(ResponseType), "counter"),
+                      ["test", "127_0_0_2", "bad", eradius_test_handler:localhost(atom), "1813"],
+                      1),
+    ok = check_metric(?SERVER_ID_FORMAT_BAD("request", atom_to_list(RequestType), "counter"),
+                      ["bad", eradius_test_handler:localhost(atom), "1813", "bad_nas", "127_0_0_2"],
+                      1),
+    ok = check_metric(?SERVER_ID_FORMAT_BAD("response", atom_to_list(ResponseType), "counter"),
+                      ["bad", eradius_test_handler:localhost(atom), "1813", "bad_nas", "127_0_0_2"],
+                      1),
+    ok = check_metric(?SERVER_ID_FORMAT_BAD_TOTAL("request", atom_to_list(RequestType), "counter"),
+                      ["bad", eradius_test_handler:localhost(atom), "1813"],
+                      1),
+    ok = check_metric(?SERVER_ID_FORMAT_BAD_TOTAL("response", atom_to_list(ResponseType), "counter"),
+                      ["bad", eradius_test_handler:localhost(atom), "1813"],
+                      1);
 check_single_request(error, EradiusRequestType, RequestType, ResponseType) ->
-    ok = send_request(EradiusRequestType, eradius_test_handler:localhost(tuple), 1814, ?ATTRS_ERROR, [{server_name, error}, {client_name, test}, {timeout, 1000}]),
-    ok = check_metric(?CLIENT_ID_FORMAT_ERROR(request, RequestType, counter), 1),
-    ok = check_metric(?CLIENT_ID_FORMAT_ERROR(request, retransmission, counter), 1),
-    ok = check_metric(?SERVER_ID_FORMAT_ERROR(request, RequestType, counter), 1),
-    ok = check_metric(?SERVER_ID_FORMAT_ERROR(response, ResponseType, counter), 1),
-    ok = check_metric(?SERVER_ID_FORMAT_ERROR(request, duplicate, counter), 1),
+    ok = send_request(EradiusRequestType, eradius_test_handler:localhost(tuple), 1814, ?ATTRS_ERROR,
+                      [{server_name, error}, {client_name, test}, {timeout, 1000}]),
+    ok = check_metric(?CLIENT_ID_FORMAT_ERROR("request", atom_to_list(RequestType), "counter"),
+                      ["test", "127_0_0_2", "error", eradius_test_handler:localhost(atom), "1814"],
+                      1),
+    ok = check_metric(?CLIENT_ID_FORMAT_ERROR("request", "retransmission", "counter"),
+                      ["test", "127_0_0_2", "error", eradius_test_handler:localhost(atom), "1814"],
+                      1),
+    ok = check_metric(?SERVER_ID_FORMAT_ERROR("request", atom_to_list(RequestType), "counter"),
+                      ["error", eradius_test_handler:localhost(atom), "1814", "error_nas", "127_0_0_2"],
+                      1),
+    ok = check_metric(?SERVER_ID_FORMAT_ERROR("response", atom_to_list(ResponseType), "counter"),
+                      ["error", eradius_test_handler:localhost(atom), "1814", "error_nas", "127_0_0_2"],
+                      1),
+    ok = check_metric(?SERVER_ID_FORMAT_ERROR("request", "duplicate", "counter"),
+                      ["error", eradius_test_handler:localhost(atom), "1814", "error_nas", "127_0_0_2"],
+                      1),
     %% retransmissions don't count into client statistics
-    ok = check_metric(?CLIENT_ID_FORMAT_ERROR(request, total, counter), 1),
-    ok = check_metric(?SERVER_ID_FORMAT_ERROR(request, total, counter), 2).
+    ok = check_metric(?CLIENT_ID_FORMAT_ERROR("request", "total", "counter"),
+                      ["test", "127_0_0_2", "error", eradius_test_handler:localhost(atom), "1814"],
+                      1),
+    ok = check_metric(?SERVER_ID_FORMAT_ERROR("request", "total", "counter"),
+                      ["error", eradius_test_handler:localhost(atom), "1814", "error_nas", "127_0_0_2"],
+                      2).
 
 check_total_requests(good, N) ->
-    ok = check_metric(?SERVER_ID_FORMAT_GOOD_TOTAL(request, total, counter), N),
-    ok = check_metric(?SERVER_ID_FORMAT_GOOD_TOTAL(response, total, counter), N);
+    ok = check_metric(?SERVER_ID_FORMAT_GOOD_TOTAL("request", "total", "counter"),
+                      ["good", eradius_test_handler:localhost(atom), "1812"],
+                      N),
+    ok = check_metric(?SERVER_ID_FORMAT_GOOD_TOTAL("response", "total", "counter"),
+                      ["good", eradius_test_handler:localhost(atom), "1812"],
+                      N);
 check_total_requests(bad, N) ->
-    ok = check_metric(?SERVER_ID_FORMAT_BAD_TOTAL(request, total, counter), N),
-    ok = check_metric(?SERVER_ID_FORMAT_BAD_TOTAL(response, total, counter), N).
+    ok = check_metric(?SERVER_ID_FORMAT_BAD_TOTAL("request", "total", "counter"),
+                      ["bad", eradius_test_handler:localhost(atom), "1813"],
+                      N),
+    ok = check_metric(?SERVER_ID_FORMAT_BAD_TOTAL("response", "total", "counter"),
+                      ["bad", eradius_test_handler:localhost(atom), "1813"],
+                      N).
 
-check_metric(Id, Count) ->
-    case exometer:get_value(Id) of
-        {ok, [{value, Count} | _]} ->
-            ok;
-        Else ->
+check_metric(Id, Labels, Count) ->
+    case prometheus_counter:value(Id, Labels) of
+	Count ->
+	    ok;
+	Else ->
             {error, {Count, Else}}
     end.
-
 
 send_request(Command, IP, Port, Attrs, Opts) ->
     ok = eradius_dict:load_tables([dictionary]),

--- a/test/eradius_test_handler.erl
+++ b/test/eradius_test_handler.erl
@@ -48,4 +48,4 @@ localhost(tuple) ->
 localhost(ip) ->
     inet:ntoa(localhost(tuple));
 localhost(atom) ->
-    list_to_atom(localhost(ip)).
+    string:join(string:replace(localhost(ip), ".", "_", all), "").

--- a/test/readme.md
+++ b/test/readme.md
@@ -31,7 +31,3 @@ or
 You now should find something simmilar to the following message in your journal:
 
     `Feb 13 17:09:52 tpiadmin-HP-EliteBook-8470p beam.smp[11790]: 127.0.0.1:39534 [27]: Access-Request`
-
-Don't forget to add reporter before `exometer_core` will be started:
-
-	`application:set_env(exometer, report, [{reporters, [{exometer_report_tty, []}]}]).`


### PR DESCRIPTION
These commits replaces exometer/exometer_core libraries with prometheus.erl to collect RADIUS metrics.
    
All metrics names are preserved as it was before. Only internal structure of metrics names changed as exometer stored metrics names as list of atoms, but prometheus stores metrics names as binary strings. In addition variadic parts of metrics names moved to prometheus labels.

So before it was:

```
[request, invalid, server, $NAME, $IP, $PORT, total, undefined, undefined, gauge]
```

Now it is:

```
request_invalid_server_total_undefined_undefined_gauge
```

with `[$NAME, $IP, $PORT]` labels.
    
The one backward compatibility change is - prometheus histogram observations are stored into buckets, but exometer histograms collected data and calculated quantiles. Now calculation of quantiles should be done on prometheus site via prometheus functions.
