### PR TITLE
add support for failover to RADIUS client

### DIFF
--- a/test/eradius_test_handler.erl
+++ b/test/eradius_test_handler.erl
@@ -2,7 +2,7 @@
 
 -behaviour(eradius_server).
 
--export([start/0, stop/0, send_request/1, radius_request/3]).
+-export([start/0, stop/0, send_request/1, send_request_failover/1, radius_request/3]).
 -export([localhost/1]).
 
 -include("include/eradius_lib.hrl").
@@ -15,6 +15,8 @@ start() ->
     application:set_env(eradius, one, [{{"ONE", []}, [{localhost(ip), "secret"}]}]),
     application:set_env(eradius, servers, [{one, {localhost(ip), [1812]}}]),
     application:set_env(eradius, metrics, []),
+    application:set_env(eradius, unreachable_timeout, 2),
+    application:set_env(eradius, servers_pool, [{test_pool, [{localhost(tuple), 1812, "secret"}]}]),
     application:ensure_all_started(eradius),
     eradius:modules_ready([?MODULE]).
 
@@ -25,6 +27,15 @@ stop() ->
 
 send_request(IP) ->
     {ok, R, A} = eradius_client:send_request({IP, 1812, "secret"}, #radius_request{cmd = request}, []),
+    #radius_request{cmd = Cmd} = eradius_lib:decode_request(R, <<"secret">>, A),
+    Cmd.
+
+send_request_failover(Server) ->
+    {ok, Pools} = application:get_env(eradius, servers_pool),
+    SecondaryServers = proplists:get_value(test_pool, Pools),
+    {ok, R, A} = eradius_client:send_request(Server, #radius_request{cmd = request}, [{retries, 1},
+                                                                                      {timeout, 2000},
+                                                                                      {failover, SecondaryServers}]),
     #radius_request{cmd = Cmd} = eradius_lib:decode_request(R, <<"secret">>, A),
     Cmd.
 


### PR DESCRIPTION
This commit adds support for fail-over. Set of secondary RADIUS servers could be passed to the RADIUS client API eradius_client:send_request/3 via options or to RADIUS proxy via configuration.

If the response wasn't received after a number of requests specified by `retries` configuration option for the given RADIUS server - such RADIUS servers will be marked as non-active and RADIUS requests will not be sent for such `non-active` RADIUS servers. The new configuration option is represented as well in this PR - `eradius.unreachable_timeout`. This option specifies how long such `non-active` RADIUS servers should be considered as unreachable. Such `non-active` RADIUS server will be marked as active and returned to the servers pool after the timeout specified as a value of the `eradius.unreachable_timeout` option will be expired.

Secondary RADIUS servers could be specified via RADIUS proxy configuration, with the new configuration option - pool name.

For example:

```
  [{default_route, {{127, 0, 0, 1}, 1812, <<"secret">>}, pool_name},
```

Where the `pool_name` atom specifies name of a pool of secondary RADIUS servers. All pools are configured via:

```
   {servers_pool, [{pool_name, [
                     {{127, 0, 0, 2}, 1812, <<"secret">>, [{retries, 3}]},
                     {{127, 0, 0, 3}, 1812, <<"secret">>}]}]}
```

In a case when RADIUS proxy (eradius_proxy handler) is not used, a list of RADIUS upstream servers could be passed to the `eradius_client:send_radius_request/3` via options, for example:

```
eradius_client:send_request(Server, Request, [{failover, [{"localhost", 1814, <<"secret">>}]}])
```

All such active RADIUS servers will be stored in the ets table and in a case of failed RADIUS request - eradius_client will fetch next one active RADIUS server from the ets table and it will be used for next tries of sending failed RADIUS request. If `failover` option was not passed to the client through the options or RADIUS proxy configuration there should not be any performance impact as RADIUS client will try to a RADIUS request to only one RADIUS server that is defined in eradius_client:send_request/3 options.