### PR TITLE
export eradius_prometheus_collector:fetch_counter/3

### DIFF
--- a/applications/eradius_prometheus_collector/src/eradius_prometheus_collector.erl
+++ b/applications/eradius_prometheus_collector/src/eradius_prometheus_collector.erl
@@ -5,7 +5,7 @@
 -include_lib("eradius/include/eradius_lib.hrl").
 -include_lib("prometheus/include/prometheus.hrl").
 
--export([deregister_cleanup/1, collect_mf/2, collect_metrics/2, fetch_counter/2, fetch_histogram/2]).
+-export([deregister_cleanup/1, collect_mf/2, collect_metrics/2, fetch_counter/2, fetch_counter/3, fetch_histogram/2]).
 
 -import(prometheus_model_helpers, [create_mf/5, gauge_metric/2, counter_metric/1]).
 


### PR DESCRIPTION
as it could be useful to fetch counters and provide stats from outside to avoid multiple accessing of eradius_counter ets table when we need to fetch multiple counters.