### PR TITLE
fix collecting of metrics in eradius_counter_aggregator

### DIFF
--- a/src/eradius.app.src
+++ b/src/eradius.app.src
@@ -12,7 +12,7 @@
       {client_ports, 100},
       {resend_timeout, 30000},
       {logging, false},
-      {counter_aggregator, true},
+      {counter_aggregator, false},
       {logfile, "./radius.log"},
       {metrics, [{enabled, [server, nas, client]}]},
       {recbuf, 8192} % maximum socket receive buffer in bytes

--- a/src/eradius_counter_aggregator.erl
+++ b/src/eradius_counter_aggregator.erl
@@ -95,6 +95,12 @@ update_stats(Rec = #nas_counter{key = Key}) ->
                [] -> #nas_counter{key = Key};
                [Cnt] -> Cnt
     end,
+    ets:insert(?MODULE, add_counter(Cnt0, Rec));
+update_stats(Rec = #client_counter{key = Key}) ->
+    Cnt0 = case ets:lookup(?MODULE, Key) of
+               [] -> #client_counter{key = Key};
+               [Cnt] -> Cnt
+    end,
     ets:insert(?MODULE, add_counter(Cnt0, Rec)).
 
 add_counter(Cnt1 = #nas_counter{}, Cnt2 = #nas_counter{}) ->
@@ -108,6 +114,12 @@ add_counter(Cnt1 = #nas_counter{}, Cnt2 = #nas_counter{}) ->
              accessAccepts            = Cnt1#nas_counter.accessAccepts             + Cnt2#nas_counter.accessAccepts,
              accessRejects            = Cnt1#nas_counter.accessRejects             + Cnt2#nas_counter.accessRejects,
              accessChallenges         = Cnt1#nas_counter.accessChallenges          + Cnt2#nas_counter.accessChallenges,
+             accountRequestsStart     = Cnt1#nas_counter.accountRequestsStart      + Cnt2#nas_counter.accountRequestsStart,
+             accountRequestsStop      = Cnt1#nas_counter.accountRequestsStop       + Cnt2#nas_counter.accountRequestsStop,
+             accountRequestsUpdate    = Cnt1#nas_counter.accountRequestsUpdate     + Cnt2#nas_counter.accountRequestsUpdate,
+             accountResponsesStart    = Cnt1#nas_counter.accountResponsesStart     + Cnt2#nas_counter.accountResponsesStart,
+             accountResponsesStop     = Cnt1#nas_counter.accountResponsesStop      + Cnt2#nas_counter.accountResponsesStop,
+             accountResponsesUpdate   = Cnt1#nas_counter.accountResponsesUpdate    + Cnt2#nas_counter.accountResponsesUpdate,
              noRecords                = Cnt1#nas_counter.noRecords                 + Cnt2#nas_counter.noRecords,
              badAuthenticators        = Cnt1#nas_counter.badAuthenticators         + Cnt2#nas_counter.badAuthenticators,
              packetsDropped           = Cnt1#nas_counter.packetsDropped            + Cnt2#nas_counter.packetsDropped,
@@ -119,4 +131,32 @@ add_counter(Cnt1 = #nas_counter{}, Cnt2 = #nas_counter{}) ->
              discRequests             = Cnt1#nas_counter.discRequests              + Cnt2#nas_counter.discRequests,
              discAcks                 = Cnt1#nas_counter.discAcks                  + Cnt2#nas_counter.discAcks,
              discNaks                 = Cnt1#nas_counter.discNaks                  + Cnt2#nas_counter.discNaks
-            }.
+      };
+add_counter(Cnt1 = #client_counter{}, Cnt2 = #client_counter{}) ->
+    #client_counter{
+             key                      = Cnt1#client_counter.key,
+             requests                 = Cnt1#client_counter.requests               + Cnt2#client_counter.requests,
+             replies                  = Cnt1#client_counter.replies                + Cnt2#client_counter.replies,
+             accessRequests           = Cnt1#client_counter.accessRequests         + Cnt2#client_counter.accessRequests,
+             accessAccepts            = Cnt1#client_counter.accessAccepts          + Cnt2#client_counter.accessAccepts,
+             accessRejects            = Cnt1#client_counter.accessRejects          + Cnt2#client_counter.accessRejects,
+             accessChallenges         = Cnt1#client_counter.accessChallenges       + Cnt2#client_counter.accessChallenges,
+             accountRequestsStart     = Cnt1#client_counter.accountRequestsStart   + Cnt2#client_counter.accountRequestsStart,
+             accountRequestsStop      = Cnt1#client_counter.accountRequestsStop    + Cnt2#client_counter.accountRequestsStop,
+             accountRequestsUpdate    = Cnt1#client_counter.accountRequestsUpdate  + Cnt2#client_counter.accountRequestsUpdate,
+             accountResponsesStart    = Cnt1#client_counter.accountResponsesStart  + Cnt2#client_counter.accountResponsesStart,
+             accountResponsesStop     = Cnt1#client_counter.accountResponsesStop   + Cnt2#client_counter.accountResponsesStop,
+             accountResponsesUpdate   = Cnt1#client_counter.accountResponsesUpdate + Cnt2#client_counter.accountResponsesUpdate,
+             badAuthenticators        = Cnt1#client_counter.badAuthenticators      + Cnt2#client_counter.badAuthenticators,
+             packetsDropped           = Cnt1#client_counter.packetsDropped         + Cnt2#client_counter.packetsDropped,
+             unknownTypes             = Cnt1#client_counter.unknownTypes           + Cnt2#client_counter.unknownTypes,
+             coaRequests              = Cnt1#client_counter.coaRequests            + Cnt2#client_counter.coaRequests,
+             coaAcks                  = Cnt1#client_counter.coaAcks                + Cnt2#client_counter.coaAcks,
+             coaNaks                  = Cnt1#client_counter.coaNaks                + Cnt2#client_counter.coaNaks,
+             discRequests             = Cnt1#client_counter.discRequests           + Cnt2#client_counter.discRequests,
+             discAcks                 = Cnt1#client_counter.discAcks               + Cnt2#client_counter.discAcks,
+             discNaks                 = Cnt1#client_counter.discNaks               + Cnt2#client_counter.discNaks,
+             retransmissions          = Cnt1#client_counter.retransmissions        + Cnt2#client_counter.retransmissions,
+             timeouts                 = Cnt1#client_counter.timeouts               + Cnt2#client_counter.timeouts,
+             pending                  = Cnt1#client_counter.pending                + Cnt2#client_counter.pending
+      }.

--- a/src/eradius_counter_aggregator.erl
+++ b/src/eradius_counter_aggregator.erl
@@ -37,7 +37,7 @@ start_link() ->
 init([]) ->
     ets:new(?MODULE, [ordered_set, protected, named_table, {keypos, #nas_counter.key}, {write_concurrency,true}]),
     eradius:modules_ready([?MODULE]),
-    EnableAggregator = application:get_env(eradius, counter_aggregator, true),
+    EnableAggregator = application:get_env(eradius, counter_aggregator, false),
     if EnableAggregator == true ->
             erlang:send_after(?INIT_HB, self(), heartbeat);
        true ->


### PR DESCRIPTION
In a case of enabled eradius_counter_aggregator - it collects metrics
values by heartbeat timeout. Since f68fdbfe57 we have added client metrics,
so not only nas_counter{} record could be passed to the
eradius_counter_aggregator:update_stats/1 but also client_counter{}. In this
case there will be function clause error as right now update_stats/1 accepts
only nas_counter{} parameter.

This commit fixes this by adding new clause to accept client_counter{} record
in eradius_counter_aggregator:update_stats/1