### PR TITLE
Update deps: meck, stacktrace_compat

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,10 +2,6 @@
 {erl_opts, [debug_info]}.
 {minimum_otp_vsn, "21.1"}.
 
-{deps, [
-	{stacktrace_compat, "1.0.2"}
-]}.
-
 {pre_hooks, [{compile, "escript dicts_compiler.erl compile"},
 	     {clean, "escript dicts_compiler.erl clean"}]}.
 
@@ -13,7 +9,7 @@
 	    {test, [
 		    {erl_opts, [nowarn_export_all]},
                     {project_app_dirs, ["applications/*", "src/*", "."]},
-		    {deps, [{meck, "0.8.13"}]},
+		    {deps, [{meck, "0.9.0"}]},
 		    {plugins, [coveralls]}
 		   ]}
 	   ]}.


### PR DESCRIPTION
* `meck` - https://github.com/eproxus/meck/blob/master/CHANGELOG.md
* Due to `eradius` description:
```
Erlang Version Support
All minor version of the current major release and the highest minor version of the previous major release will be supported.  
At the moment this means OTP 21.3, OTP 22.x and OTP 23.x are supported. OTP versions before 21.0 do not work due the use of logger.  
When in doubt check the otp_release section in .travis.yml for tested versions.
```
and due to fact that `meck` have logic for checking release version with using both syntaxes, no make sense include `stacktrace_compat` and follow the update of this library at all, by this reason I suppose make sense remove `stacktrace_compat` from `eradius`