### PR TITLE
Remove metrics env what was use for exameter

### DIFF
--- a/src/eradius.app.src
+++ b/src/eradius.app.src
@@ -14,7 +14,6 @@
       {logging, false},
       {counter_aggregator, false},
       {logfile, "./radius.log"},
-      {metrics, [{enabled, [server, nas, client]}]},
       {recbuf, 8192}
    ]},
    {maintainers, ["Andreas Schultz", "Vladimir Tarasenko", "Yury Gargay"]},

--- a/test/eradius_metrics_SUITE.erl
+++ b/test/eradius_metrics_SUITE.erl
@@ -52,8 +52,6 @@ init_per_suite(Config) ->
                               { {"error", [] }, [{"127.0.0.2", ?SECRET, [{nas_id, <<"error_nas">>}]}] }
                              ]},
                      {tables, [dictionary]},
-                     {metrics, [{enabled, [server, nas, client]},
-                                {subscribe_opts, []}]},
                      {client_ip, {127,0,0,2}},
                      {client_ports, 20},
                      {counter_aggregator, false}

--- a/test/eradius_test_handler.erl
+++ b/test/eradius_test_handler.erl
@@ -14,7 +14,6 @@ start() ->
     application:set_env(eradius, session_nodes, local),
     application:set_env(eradius, one, [{{"ONE", []}, [{localhost(ip), "secret"}]}]),
     application:set_env(eradius, servers, [{one, {localhost(ip), [1812]}}]),
-    application:set_env(eradius, metrics, []),
     application:set_env(eradius, unreachable_timeout, 2),
     application:set_env(eradius, servers_pool, [{test_pool, [{localhost(tuple), 1812, "secret"}]}]),
     application:ensure_all_started(eradius),


### PR DESCRIPTION
Remove unused config option `metrics`