### PR TITLE
use prometheus_histogram:declare/1 instead prometheus_histogram:new/1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -19,7 +19,7 @@
 	       locals_not_used, deprecated_function_calls,
 	       deprecated_functions]}.
 
-{xref_ignores, [{prometheus_histogram, new, 1},
+{xref_ignores, [{prometheus_histogram, declare, 1},
                 {prometheus_histogram, observe, 3}]}.
 
 %% == Cover ==

--- a/src/eradius_counter.erl
+++ b/src/eradius_counter.erl
@@ -95,8 +95,8 @@ observe(Name, {{ClientName, ClientIP, _}, {ServerName, ServerIP, ServerPort}} = 
                 prometheus_histogram:observe(Name, [ServerIP, ServerPort, ServerName, ClientName, ClientIP], Value)
             catch _:_ ->
                     Buckets = application:get_env(eradius, histogram_buckets, [10, 30, 50, 75, 100, 1000, 2000]),
-                    prometheus_histogram:new([{name, Name}, {labels, [server_ip, server_port, server_name, client_name, client_ip]},
-                                              {buckets, Buckets}, {help, Help}]),
+                    prometheus_histogram:declare([{name, Name}, {labels, [server_ip, server_port, server_name, client_name, client_ip]},
+                                                  {buckets, Buckets}, {help, Help}]),
                     observe(Name, MetricsInfo, Value, Help)
             end;
         _ ->
@@ -109,8 +109,8 @@ observe(Name, #nas_prop{server_ip = ServerIP, server_port = ServerPort, nas_ip =
                 prometheus_histogram:observe(Name, [inet:ntoa(ServerIP), ServerPort, ServerName, inet:ntoa(NasIP), NasId], Value)
             catch _:_ ->
                     Buckets = application:get_env(eradius, histogram_buckets, [10, 30, 50, 75, 100, 1000, 2000]),
-                    prometheus_histogram:new([{name, Name}, {labels, [server_ip, server_port, server_name, nas_ip, nas_id]},
-                                              {buckets, Buckets}, {help, Help}]),
+                    prometheus_histogram:declare([{name, Name}, {labels, [server_ip, server_port, server_name, nas_ip, nas_id]},
+                                                  {buckets, Buckets}, {help, Help}]),
                     observe(Name, Nas, Value, ServerName, Help)
             end;
         _ ->


### PR DESCRIPTION
When a RADIUS request comes to eradius or we try to send a request from it - new histogram metric could be created. There could be a situation when a couple of RADIUS requests with the same name and similar labels come to eradius which may lead to crash because of races during creation of prometheus metric.

This commit replaces prometheus_histogram:new/1 with prometheus_histogram:declare/1 API as the first one throws an exception in a case of metric already exists.