### PR TITLE
fix building of eradius with persistent_term

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,17 +1,30 @@
 %% -*- erlang -*-
+
+ExistingErlOpts = proplists:get_value(erl_opts, CONFIG, []),
+CONFIG1 =
+  try
+      persistent_term:info(),
+      io:format("CONFIG: enabling persistent_term support~n"),
+      lists:keyreplace(erl_opts, 1, CONFIG,
+		       {erl_opts, [{d, 'HAVE_PERSISTENT_TERM'}|ExistingErlOpts]})
+  catch
+      _:_ ->
+	  CONFIG
+  end,
+
 case {os:getenv("GITHUB_ACTIONS"), os:getenv("GITHUB_TOKEN")} of
     {"true", Token} when is_list(Token) ->
-        CONFIG1 = [{coveralls_repo_token, Token},
+        CONFIG2 = [{coveralls_repo_token, Token},
         {coveralls_service_job_id, os:getenv("GITHUB_RUN_ID")},
         {coveralls_commit_sha, os:getenv("GITHUB_SHA")},
-        {coveralls_flag_name, os:getenv("COVERALLS_FLAG_NAME")} | CONFIG],
+        {coveralls_flag_name, os:getenv("COVERALLS_FLAG_NAME")} | CONFIG1],
         case os:getenv("GITHUB_EVENT_NAME") =:= "pull_request"
             andalso string:tokens(os:getenv("GITHUB_REF"), "/") of
             [_, "pull", PRNO, _] ->
-                [{coveralls_service_pull_request, PRNO} | CONFIG1];
+                [{coveralls_service_pull_request, PRNO} | CONFIG2];
             _ ->
-                CONFIG1
+                CONFIG2
         end;
     _ ->
-        CONFIG
+        CONFIG1
 end.


### PR DESCRIPTION
The HAVE_PERSISTENT_TERM option was used to build eradiusd with
persistent_term support. But it was lost in the 9dccab38040 commit.

This commit returns it back.