### PR TITLE
Update prometheus to 4.8.0

### DIFF
--- a/applications/eradius_prometheus_collector/rebar.config
+++ b/applications/eradius_prometheus_collector/rebar.config
@@ -1,3 +1,3 @@
 {deps, [
-  {prometheus, "4.6.0"}
+  {prometheus, "4.8.0"}
 ]}.


### PR DESCRIPTION
Diff hex.pm https://diff.hex.pm/diff/prometheus/4.6.0..4.8.0