### PR TITLE
Start use rebar3_hank

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
       run: rebar3 compile
     - name: Run tests
       run: |
+           rebar3 hank
            rebar3 do xref
            rebar3 do ct
     - name: Coveralls

--- a/applications/eradius_prometheus_collector/src/eradius_prometheus_collector.erl
+++ b/applications/eradius_prometheus_collector/src/eradius_prometheus_collector.erl
@@ -9,6 +9,8 @@
 
 -import(prometheus_model_helpers, [create_mf/5, gauge_metric/2, counter_metric/1]).
 
+-hank([unused_macros]).
+
 -define(METRIC_NAME_PREFIX, "eradius_").
 
 -define(METRICS, [

--- a/include/eradius_lib.hrl
+++ b/include/eradius_lib.hrl
@@ -9,23 +9,7 @@
 -type atom_address() :: {atom_name(), {atom_ip(), atom_port()}}.
 -type atom_address_pair() :: {atom_address(), atom_address()}.
 
-%%- cmds
--define(RAccess_Request,       1).
--define(RAccess_Accept,        2).
--define(RAccess_Reject,        3).
--define(RAccounting_Request,   4).
--define(RAccounting_Response,  5).
--define(RAccess_Challenge,    11).
--define(RDisconnect_Request,  40).
--define(RDisconnect_Ack,      41).
--define(RDisconnect_Nak,      42).
--define(RCoa_Request,         43).
--define(RCoa_Ack,             44).
--define(RCoa_Nak,             45).
-
 %%- attribs
--define(RUser_Name,        1).
--define(RUser_Passwd,      2).
 -define(RNAS_Ip_Address,   4).
 -define(RReply_Msg,       18).
 -define(RState,           24).
@@ -37,8 +21,6 @@
 -define(RSession_Id,      44).
 -define(RSession_Time,    46).
 -define(RTerminate_Cause, 49).
--define(REAP_Message,     79).
--define(RMessage_Authenticator, 80).
 
 %%- attribute values
 -define(RStatus_Type_Start,  1).

--- a/rebar.config
+++ b/rebar.config
@@ -27,7 +27,8 @@
 {plugins, [
     % @TODO: Folow https://github.com/markusn/coveralls-erl/pull/36 and use `coveralls` after release
     {coveralls, {git, "https://github.com/RoadRunnr/coveralls-erl.git", {branch, "feature/git-info"}}},
-    rebar3_hex]
+    rebar3_hex,
+    rebar3_hank]
 }.
 
 %% == Cover covervalls.io ==
@@ -38,3 +39,9 @@
 {coveralls_coverdata, "_build/test/cover/ct.coverdata"}.
 {coveralls_service_name , "github"}.
 {coveralls_parallel, true}.
+
+%% == Hank ==
+{hank, [{ignore, [
+    {"test/**/*.erl", unnecessary_function_arguments}, 
+    "include/dictionary*"
+]}]}.

--- a/src/eradius_config.erl
+++ b/src/eradius_config.erl
@@ -12,8 +12,6 @@
 -define(ip4_address_num(X), ?pos_int(X), X < 256).
 -define(ip4_address(T), ?ip4_address_num(element(1, T)), ?ip4_address_num(element(2, T)),
                         ?ip4_address_num(element(3, T)), ?ip4_address_num(element(4, T))).
--define(valid_atom(Value), Value =/= invalid).
--define(valid(X), is_tuple(X), ?valid_atom(element(1, X))).
 -define(is_io(IO), is_list(IO) orelse is_binary(IO)).
 -define(invalid(ErrorMsg, ErrorValue), {invalid, io_lib:format(ErrorMsg, ErrorValue)}).
 

--- a/src/eradius_lib.erl
+++ b/src/eradius_lib.erl
@@ -23,6 +23,25 @@
 -define(IS_KEY(Key, Attr), ((is_record(Attr, attribute) andalso (element(2, Attr) == Key))
                            orelse
                            (Attr == Key)) ).
+
+%%- cmds
+-define(RAccess_Request,       1).
+-define(RAccess_Accept,        2).
+-define(RAccess_Reject,        3).
+-define(RAccounting_Request,   4).
+-define(RAccounting_Response,  5).
+-define(RAccess_Challenge,    11).
+-define(RDisconnect_Request,  40).
+-define(RDisconnect_Ack,      41).
+-define(RDisconnect_Nak,      42).
+-define(RCoa_Request,         43).
+-define(RCoa_Ack,             44).
+-define(RCoa_Nak,             45).
+
+%%- attribs
+-define(REAP_Message,           79).
+-define(RMessage_Authenticator, 80).
+
 %% ------------------------------------------------------------------------------------------
 %% -- Request Accessors
 -spec random_authenticator() -> authenticator().

--- a/src/eradius_server.erl
+++ b/src/eradius_server.erl
@@ -66,7 +66,6 @@
 -include("dictionary.hrl").
 -include("eradius_dict.hrl").
 
--define(RESEND_TIMEOUT, 5000).          % how long the binary response is kept after sending it on the socket
 -define(RESEND_RETRIES, 3).             % how often a reply may be resent
 -define(HANDLER_REPLY_TIMEOUT, 15000).  % how long to wait before a remote handler is considered dead
 
@@ -83,6 +82,8 @@
     counter        :: #server_counter{}, % statistics counter,
     name           :: atom()             % server name
 }).
+
+-hank([unused_callbacks]).
 
 -optional_callbacks([validate_arguments/1]).
 

--- a/test/eradius_auth_SUITE.erl
+++ b/test/eradius_auth_SUITE.erl
@@ -56,9 +56,6 @@ all() -> [
 %% 16-octet PeerChallenge:
 -define(PEER_CHALLENGE, <<16#21, 16#40, 16#23, 16#24, 16#25, 16#5E, 16#26, 16#2A, 16#28, 16#29, 16#5F, 16#2B, 16#3A, 16#33, 16#7C, 16#7E>>).
 
-%% 8-octet Challenge:
--define(CHALLENGE, <<16#D0, 16#2E, 16#43, 16#86, 16#BC, 16#E9, 16#12, 16#26>>).
-
 %% 16-octet PasswordHash:
 -define(PASSWORD_HASH, <<16#44, 16#EB, 16#BA, 16#8D, 16#53, 16#12, 16#B8, 16#D6, 16#11, 16#47, 16#44, 16#11, 16#F5, 16#69, 16#89, 16#AE>>).
 
@@ -74,11 +71,8 @@ all() -> [
 %% MPPE keys
 -define(MASTER_KEY, <<16#FD, 16#EC, 16#E3, 16#71, 16#7A, 16#8C, 16#83, 16#8C, 16#B3, 16#88, 16#E5, 16#27, 16#AE, 16#3C, 16#DD, 16#31>>).
 -define(SEND_START_KEY40, <<16#8B, 16#7C, 16#DC, 16#14, 16#9B, 16#99, 16#3A, 16#1B>>).
--define(SEND_SESSION_KEY40, <<16#D1, 16#26, 16#9E, 16#C4, 16#9F, 16#A6, 16#2E, 16#3E>>).
 -define(SEND_START_KEY56, <<16#8B, 16#7C, 16#DC, 16#14, 16#9B, 16#99, 16#3A, 16#1B>>).
--define(SEND_SESSION_KEY56, <<16#D1, 16#5C, 16#00, 16#C4, 16#9F, 16#A6, 16#2E, 16#3E>>).
 -define(SEND_START_KEY128, <<16#8B, 16#7C, 16#DC, 16#14, 16#9B, 16#99, 16#3A, 16#1B, 16#A1, 16#18, 16#CB, 16#15, 16#3F, 16#56, 16#DC, 16#CB>>).
--define(SEND_SESSION_KEY128, <<16#40, 16#5C, 16#B2, 16#24, 16#7A, 16#79, 16#56, 16#E6, 16#E2, 16#11, 16#00, 16#7A, 16#E2, 16#7B, 16#22, 16#D4>>).
 
 %% 0-to-256-unicode-char Password:
 -define(PASSWORD2, <<16#4D, 16#79, 16#50, 16#77>>).

--- a/test/eradius_client_SUITE.erl
+++ b/test/eradius_client_SUITE.erl
@@ -151,8 +151,8 @@ test(false, Msg) ->
 
 check(OldState, NewState = #state{no_ports = P}, null, A) -> check(OldState, NewState, P, A);
 check(OldState, NewState = #state{socket_ip = A}, P, null) -> check(OldState, NewState, P, A);
-check(#state{sockets = OS, no_ports = _OP, idcounters = _OC, socket_ip = OA},
-        #state{sockets = NS, no_ports = NP, idcounters = NC, socket_ip = NA},
+check(#state{sockets = OS, no_ports = _OP, idcounters = _OC, socket_ip = OA, sup = _, subscribed_clients = _},
+        #state{sockets = NS, no_ports = NP, idcounters = NC, socket_ip = NA, sup = _, subscribed_clients = _},
         P, A) ->
     {ok, PA} = parse_ip(A),
     test(PA == NA, "Adress not configured") and

--- a/test/eradius_client_socket_test.erl
+++ b/test/eradius_client_socket_test.erl
@@ -25,7 +25,7 @@
 -export([start/3]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
 
--record(state, {client, socket, pending, mode, counter}).
+-record(state, {pending, mode, counter}).
 
 start(SocketIP, Client, PortIdx) ->
     gen_server:start_link(?MODULE, [SocketIP, Client, PortIdx], []).

--- a/test/eradius_lib_SUITE.erl
+++ b/test/eradius_lib_SUITE.erl
@@ -34,7 +34,8 @@
 -define(ENC_PASSWORD, 186,128,194,207,68,25,190,19,23,226,48,206,244,143,56,238).
 -define(ENC_PASSWORD_ASCEND, 222,170,194,83,115,231,228,55,75,17,20,6,198,33,112,197).
 -define(PDU, #radius_request{ reqid = 1, secret = ?SECRET, authenticator = ?REQUEST_AUTHENTICATOR }).
-
+-define(RUser_Passwd, 2).
+-define(RUser_Name, 1).
 
 %% test callbacks
 all() -> [ipv6prefix,

--- a/test/eradius_logtest.erl
+++ b/test/eradius_logtest.erl
@@ -33,12 +33,6 @@
 -define(SECRET2, <<"proxy_secret">>).
 -define(SECRET3, <<"test_secret">>).
 
--define(CLIENT_REQUESTS_COUNT, 1).
--define(CLIENT_PROXY_REQUESTS_COUNT, 4).
-
--define(NAS1_ACCESS_REQS, 1).
--define(NAS2_ACCESS_REQS, 4).
-
 start() ->
     application:load(eradius),
     ProxyConfig = [{default_route, {eradius_test_handler:localhost(tuple), 1813, ?SECRET}},

--- a/test/eradius_metrics_SUITE.erl
+++ b/test/eradius_metrics_SUITE.erl
@@ -29,7 +29,7 @@
 -define(ATTRS_GOOD, [{?NAS_Identifier, "good"}, {?RStatus_Type, ?RStatus_Type_Start}]).
 -define(ATTRS_BAD, [{?NAS_Identifier, "bad"}]).
 -define(ATTRS_ERROR, [{?NAS_Identifier, "error"}]).
--define(LOCALHOST, eradius_test_handler:localhost(atom)).
+-define(LOCALHOST, eradius_test_handler:localhost(ip)).
 
 %% test callbacks
 all() -> [good_requests, bad_requests, error_requests].
@@ -37,9 +37,9 @@ all() -> [good_requests, bad_requests, error_requests].
 init_per_suite(Config) ->
     application:load(eradius),
     EradiusConfig = [{radius_callback, ?MODULE},
-                     {servers, [{good,  {eradius_test_handler:localhost(ip), [1812]}},  %% for 'positive' responses, e.g. access accepts
-                                {bad,  {eradius_test_handler:localhost(ip), [1813]}},   %% for 'negative' responses, e.g. coa naks
-                                {error,  {eradius_test_handler:localhost(ip), [1814]}}  %% here things go wrong, e.g. duplicate requests
+                     {servers, [{good,  {?LOCALHOST, [1812]}},  %% for 'positive' responses, e.g. access accepts
+                                {bad,  {?LOCALHOST, [1813]}},   %% for 'negative' responses, e.g. coa naks
+                                {error,  {?LOCALHOST, [1814]}}  %% here things go wrong, e.g. duplicate requests
                                ]},
                      {session_nodes, [node()]},
                      {good, [


### PR DESCRIPTION
* Added `rebar3_hank`
* Added few rules for ignore couple places
* Added `rebar3_hank`run into GH Actions
* Fixed `rebar3_hank` warnings

Total of warnings:
```erlang
===> The following pieces of code are dead and should be removed:
test/eradius_client_socket_test.erl:28: Field socket in record state is unused
test/eradius_client_socket_test.erl:28: Field client in record state is unused
test/eradius_client_SUITE.erl:114: Field subscribed_clients in record state is unused
test/eradius_client_SUITE.erl:113: Field sup in record state is unused
test/eradius_metrics_SUITE.erl:32: ?LOCALHOST is unused
test/eradius_logtest.erl:36: ?CLIENT_REQUESTS_COUNT is unused
test/eradius_logtest.erl:37: ?CLIENT_PROXY_REQUESTS_COUNT is unused
test/eradius_logtest.erl:39: ?NAS1_ACCESS_REQS is unused
test/eradius_logtest.erl:40: ?NAS2_ACCESS_REQS is unused
test/eradius_auth_SUITE.erl:60: ?CHALLENGE is unused
test/eradius_auth_SUITE.erl:77: ?SEND_SESSION_KEY40 is unused
test/eradius_auth_SUITE.erl:79: ?SEND_SESSION_KEY56 is unused
test/eradius_auth_SUITE.erl:81: ?SEND_SESSION_KEY128 is unused
src/eradius_server.erl:69: ?RESEND_TIMEOUT is unused
src/eradius_config.erl:15: ?valid_atom/1 is unused
src/eradius_config.erl:16: ?valid/1 is unused
applications/eradius_prometheus_collector/src/eradius_prometheus_collector.erl:12: ?METRIC_NAME_PREFIX is unused
src/eradius_server.erl:89: Callback validate_arguments/1 is not used anywhere in the module
test/eradius_proxy_SUITE.erl:148: strip_test/1 doesn't need its #1 argument
test/eradius_proxy_SUITE.erl:137: get_key_test/1 doesn't need its #1 argument
test/eradius_proxy_SUITE.erl:129: new_request_test/1 doesn't need its #1 argument
test/eradius_proxy_SUITE.erl:115: validate_options_test/1 doesn't need its #1 argument
test/eradius_proxy_SUITE.erl:68: validate_arguments_test/1 doesn't need its #1 argument
test/eradius_proxy_SUITE.erl:36: resolve_routes_test/1 doesn't need its #1 argument
test/eradius_metrics_SUITE.erl:174: radius_request/3 doesn't need its #3 argument
test/eradius_metrics_SUITE.erl:95: check_single_request/4 doesn't need its #4 argument
test/eradius_metrics_SUITE.erl:95: check_single_request/4 doesn't need its #3 argument
test/eradius_metrics_SUITE.erl:91: error_requests/1 doesn't need its #1 argument
test/eradius_metrics_SUITE.erl:83: bad_requests/1 doesn't need its #1 argument
test/eradius_metrics_SUITE.erl:74: good_requests/1 doesn't need its #1 argument
test/eradius_metrics_SUITE.erl:68: end_per_suite/1 doesn't need its #1 argument
test/eradius_logtest.erl:92: validate_arguments/1 doesn't need its #1 argument
test/eradius_logtest.erl:80: radius_request/3 doesn't need its #3 argument
test/eradius_logtest.erl:80: radius_request/3 doesn't need its #2 argument
test/eradius_lib_SUITE.erl:163: vendor_attribute_id_conflict_test/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:159: dec_vendor_ipv4_t/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:155: dec_vendor_string_t/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:151: dec_vendor_integer_t/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:147: dec_simple_ipv4_test/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:143: dec_simple_string_test/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:139: dec_simple_integer_test/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:132: enc_vendor_octet_test/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:127: enc_vendor_test/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:123: enc_ascend_test/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:117: enc_salt_test/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:113: enc_scramble_test/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:109: enc_simple_test/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:106: ascend_dec_test/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:103: ascend_enc_test/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:100: scramble_dec_test/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:97: scramble_enc_test/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:94: salt_decrypt_test/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:91: salt_encrypt_test/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:76: ipv6prefix/1 doesn't need its #1 argument
test/eradius_lib_SUITE.erl:63: end_per_suite/1 doesn't need its #1 argument
test/eradius_config_SUITE.erl:223: generate_ip_list_test/1 doesn't need its #1 argument
test/eradius_config_SUITE.erl:177: log_test/1 doesn't need its #1 argument
test/eradius_config_SUITE.erl:128: config_with_ranges/1 doesn't need its #1 argument
test/eradius_config_SUITE.erl:121: config_nas_removing/1 doesn't need its #1 argument
test/eradius_config_SUITE.erl:77: config_2/1 doesn't need its #1 argument
test/eradius_config_SUITE.erl:37: config_1/1 doesn't need its #1 argument
test/eradius_config_SUITE.erl:33: end_per_suite/1 doesn't need its #1 argument
test/eradius_client_SUITE.erl:219: send_request_failover/1 doesn't need its #1 argument
test/eradius_client_SUITE.erl:214: reconf_ports_10/1 doesn't need its #1 argument
test/eradius_client_SUITE.erl:209: reconf_ports_30/1 doesn't need its #1 argument
test/eradius_client_SUITE.erl:204: reconf_address/1 doesn't need its #1 argument
test/eradius_client_SUITE.erl:192: wanna_send/1 doesn't need its #1 argument
test/eradius_client_SUITE.erl:177: send_request/1 doesn't need its #1 argument
test/eradius_client_SUITE.erl:47: end_per_suite/1 doesn't need its #1 argument
test/eradius_auth_SUITE.erl:135: mppe_start_key128_test/1 doesn't need its #1 argument
test/eradius_auth_SUITE.erl:132: mppe_start_key56_test/1 doesn't need its #1 argument
test/eradius_auth_SUITE.erl:129: mppe_start_key40_test/1 doesn't need its #1 argument
test/eradius_auth_SUITE.erl:126: mppe_sendstart_key128_test/1 doesn't need its #1 argument
test/eradius_auth_SUITE.erl:123: mppe_sendstart_key56_test/1 doesn't need its #1 argument
test/eradius_auth_SUITE.erl:120: mppe_sendstart_key40_test/1 doesn't need its #1 argument
test/eradius_auth_SUITE.erl:117: mppe_master_key_test/1 doesn't need its #1 argument
test/eradius_auth_SUITE.erl:114: v2_authenticator_test/1 doesn't need its #1 argument
test/eradius_auth_SUITE.erl:111: nt_response_test/1 doesn't need its #1 argument
test/eradius_auth_SUITE.erl:108: des_key_test/1 doesn't need its #1 argument
test/eradius_auth_SUITE.erl:105: password_hash2_test/1 doesn't need its #1 argument
test/eradius_auth_SUITE.erl:102: password_hashhash_test/1 doesn't need its #1 argument
test/eradius_auth_SUITE.erl:99: unicode_password_hash_test/1 doesn't need its #1 argument
test/eradius_auth_SUITE.erl:96: password_hash_test/1 doesn't need its #1 argument
test/eradius_auth_SUITE.erl:92: unicode_test/1 doesn't need its #1 argument
include/eradius_lib.hrl:13: ?RAccess_Request is used only at src/eradius_lib.erl
include/eradius_lib.hrl:14: ?RAccess_Accept is used only at src/eradius_lib.erl
include/eradius_lib.hrl:15: ?RAccess_Reject is used only at src/eradius_lib.erl
include/eradius_lib.hrl:16: ?RAccounting_Request is used only at src/eradius_lib.erl
include/eradius_lib.hrl:17: ?RAccounting_Response is used only at src/eradius_lib.erl
include/eradius_lib.hrl:18: ?RAccess_Challenge is used only at src/eradius_lib.erl
include/eradius_lib.hrl:19: ?RDisconnect_Request is used only at src/eradius_lib.erl
include/eradius_lib.hrl:20: ?RDisconnect_Ack is used only at src/eradius_lib.erl
include/eradius_lib.hrl:21: ?RDisconnect_Nak is used only at src/eradius_lib.erl
include/eradius_lib.hrl:22: ?RCoa_Request is used only at src/eradius_lib.erl
include/eradius_lib.hrl:23: ?RCoa_Ack is used only at src/eradius_lib.erl
include/eradius_lib.hrl:24: ?RCoa_Nak is used only at src/eradius_lib.erl
include/eradius_lib.hrl:27: ?RUser_Name is used only at test/eradius_lib_SUITE.erl
include/eradius_lib.hrl:28: ?RUser_Passwd is used only at test/eradius_lib_SUITE.erl
include/eradius_lib.hrl:40: ?REAP_Message is used only at src/eradius_lib.erl
include/eradius_lib.hrl:41: ?RMessage_Authenticator is used only at src/eradius_lib.erl
```