### PR TITLE
Fix gathering of RADIUS Accounting metrics

### DIFF
--- a/src/eradius_client.erl
+++ b/src/eradius_client.erl
@@ -528,7 +528,10 @@ client_request_counter_account_match_spec_compile() ->
             MatchSpecCompile = ets:match_spec_compile(ets:fun2ms(fun
                 ({?RStatus_Type, ?RStatus_Type_Start})  -> accountRequestsStart;
                 ({?RStatus_Type, ?RStatus_Type_Stop})   -> accountRequestsStop;
-                ({?RStatus_Type, ?RStatus_Type_Update}) -> accountRequestsUpdate end)),
+                ({?RStatus_Type, ?RStatus_Type_Update}) -> accountRequestsUpdate;
+                ({#attribute{id = ?RStatus_Type}, ?RStatus_Type_Start})  -> accountRequestsStart;
+                ({#attribute{id = ?RStatus_Type}, ?RStatus_Type_Stop})   -> accountRequestsStop;
+                ({#attribute{id = ?RStatus_Type}, ?RStatus_Type_Update}) -> accountRequestsUpdate end)),
             persistent_term:put({?MODULE, ?FUNCTION_NAME}, MatchSpecCompile),
             MatchSpecCompile;
         MatchSpecCompile ->
@@ -541,7 +544,10 @@ client_response_counter_account_match_spec_compile() ->
             MatchSpecCompile = ets:match_spec_compile(ets:fun2ms(fun
                 ({?RStatus_Type, ?RStatus_Type_Start})  -> accountResponsesStart;
                 ({?RStatus_Type, ?RStatus_Type_Stop})   -> accountResponsesStop;
-                ({?RStatus_Type, ?RStatus_Type_Update}) -> accountResponsesUpdate end)),
+                ({?RStatus_Type, ?RStatus_Type_Update}) -> accountResponsesUpdate;
+                ({#attribute{id = ?RStatus_Type}, ?RStatus_Type_Start})  -> accountResponsesStart;
+                ({#attribute{id = ?RStatus_Type}, ?RStatus_Type_Stop})   -> accountResponsesStop;
+                ({#attribute{id = ?RStatus_Type}, ?RStatus_Type_Update}) -> accountResponsesUpdate end)),
             persistent_term:put({?MODULE, ?FUNCTION_NAME}, MatchSpecCompile),
             MatchSpecCompile;
         MatchSpecCompile ->
@@ -554,13 +560,19 @@ client_request_counter_account_match_spec_compile() ->
     ets:match_spec_compile(ets:fun2ms(fun
         ({?RStatus_Type, ?RStatus_Type_Start})  -> accountRequestsStart;
         ({?RStatus_Type, ?RStatus_Type_Stop})   -> accountRequestsStop;
-        ({?RStatus_Type, ?RStatus_Type_Update}) -> accountRequestsUpdate end)).
+        ({?RStatus_Type, ?RStatus_Type_Update}) -> accountRequestsUpdate;
+        ({#attribute{id = ?RStatus_Type}, ?RStatus_Type_Start})  -> accountRequestsStart;
+        ({#attribute{id = ?RStatus_Type}, ?RStatus_Type_Stop})   -> accountRequestsStop;
+        ({#attribute{id = ?RStatus_Type}, ?RStatus_Type_Update}) -> accountRequestsUpdate end)).
 
 client_response_counter_account_match_spec_compile() ->
     ets:match_spec_compile(ets:fun2ms(fun
         ({?RStatus_Type, ?RStatus_Type_Start})  -> accountResponsesStart;
         ({?RStatus_Type, ?RStatus_Type_Stop})   -> accountResponsesStop;
-        ({?RStatus_Type, ?RStatus_Type_Update}) -> accountResponsesUpdate end)).
+        ({?RStatus_Type, ?RStatus_Type_Update}) -> accountResponsesUpdate;
+        ({#attribute{id = ?RStatus_Type}, ?RStatus_Type_Start})  -> accountResponsesStart;
+        ({#attribute{id = ?RStatus_Type}, ?RStatus_Type_Stop})   -> accountResponsesStop;
+        ({#attribute{id = ?RStatus_Type}, ?RStatus_Type_Update}) -> accountResponsesUpdate end)).
 
 -endif.
 

--- a/test/eradius_metrics_SUITE.erl
+++ b/test/eradius_metrics_SUITE.erl
@@ -29,10 +29,11 @@
 -define(ATTRS_GOOD, [{?NAS_Identifier, "good"}, {?RStatus_Type, ?RStatus_Type_Start}]).
 -define(ATTRS_BAD, [{?NAS_Identifier, "bad"}]).
 -define(ATTRS_ERROR, [{?NAS_Identifier, "error"}]).
+-define(ATTRS_AS_RECORD, [{#attribute{id = ?RStatus_Type}, ?RStatus_Type_Start}]).
 -define(LOCALHOST, eradius_test_handler:localhost(atom)).
 
 %% test callbacks
-all() -> [good_requests, bad_requests, error_requests].
+all() -> [good_requests, bad_requests, error_requests, request_with_attrs_as_record].
 
 init_per_suite(Config) ->
     application:load(eradius),
@@ -90,6 +91,10 @@ bad_requests(_Config) ->
 
 error_requests(_Config) ->
     check_single_request(error, request, access, access_accept).
+
+request_with_attrs_as_record(_Config) ->
+    ok = send_request(accreq, eradius_test_handler:localhost(tuple), 1812, ?ATTRS_AS_RECORD, [{server_name, good}, {client_name, test_records}]),
+    ok = check_metric(accreq, client_accounting_requests_total, [{server_name, good}, {client_name, test_records}, {acct_type, start}], 1).
 
 %% helpers
 check_single_request(good, EradiusRequestType, _RequestType, _ResponseType) ->


### PR DESCRIPTION
We are using ets:match_spec_run/2 to go over given attributes to
match type of RADIUS Accounting request to update a certain metric by
RADIUS Accounting type.

The issue is that we may get RADIUS attributes during sending of a RADIUS
request in two following formats:

   * [{AttrId, Value}, ...]
   * [#attribute{}, ....]

But only the first one could be matched in ets:match_spec_run/2. Thus if
RADIUS attributes will be given in the second format - a RADIUS Accounting
client metric will not be updated.

This commit fixes this situation.