### PR TITLE
Add server_status metric

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -19,7 +19,9 @@
 	       deprecated_functions]}.
 
 {xref_ignores, [{prometheus_histogram, declare, 1},
-                {prometheus_histogram, observe, 3}]}.
+                {prometheus_histogram, observe, 3},
+                {prometheus_boolean,   declare, 1},
+                {prometheus_boolean,   set,     3}]}.
 
 
 %% == Plugins ==

--- a/test/eradius_test_handler.erl
+++ b/test/eradius_test_handler.erl
@@ -13,9 +13,14 @@ start() ->
     application:set_env(eradius, client_ip, localhost(tuple)),
     application:set_env(eradius, session_nodes, local),
     application:set_env(eradius, one, [{{"ONE", []}, [{localhost(ip), "secret"}]}]),
-    application:set_env(eradius, servers, [{one, {localhost(ip), [1812]}}]),
+    application:set_env(eradius, two, [{{"TWO", [{default_route, {{127, 0, 0, 2}, 1813, <<"secret">>}}]},
+                                        [{localhost(ip), "secret"}]}]),
+    application:set_env(eradius, servers, [{one, {localhost(ip), [1812]}},
+                                           {two, {localhost(ip), [1813]}}]),
     application:set_env(eradius, unreachable_timeout, 2),
-    application:set_env(eradius, servers_pool, [{test_pool, [{localhost(tuple), 1812, "secret"}]}]),
+    application:set_env(eradius, servers_pool, [{test_pool, [{localhost(tuple), 1812, "secret"},
+                                                             % fake upstream server for fail-over
+                                                             {localhost(tuple), 1820, "secret"}]}]),
     application:ensure_all_started(eradius),
     eradius:modules_ready([?MODULE]).
 


### PR DESCRIPTION
**Backward compatibility is preserved and new functionality will be used only in a case when fail-over is enabled.**

This PR contains following two changes:

The first commit improves fail-over mechansim.

When RADIUS client process is started it collects all secondary RADIUS servers from RADIUS server pools into ets table to use them for fail-over. The commit adds primary servers to this ets table as well. We need this to avoid following situation: A primary 
RADIUS server was used but eradius client failed to send requests there by some reasons. So such RADIUS server will be marked as inactive for a some configurable period of time and secondary RADIUS server will be used.

The issue is that eradius client could be used again with the primary server while it is still in inactive state. This commit adds all primary and secondary servers to an ets table that stores endpoints of RADIUS servers that could be used. So if eradius client will be called with currently inactive RADIUS server - it will not be used if there is another possible active RADIUS server exists.

The second commit adds new `status_server` metric that represents an active or inactive state of a RADIUS server where eradius tries to send RADIUS requests.

The metric will represent an active or inactive state of a RADIUS server where eradius proxy client tries to send RADIUS requests. By default all possible endpoints are set to inactive. If eradius client sent a request and received successfully response such primary or secondary RADIUS server will be set to 'active' and all other
servers from the given server pool will be marked as inactive.