### PR TITLE
Make server status metrics optional

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -77,6 +77,18 @@ _All metrics start with `eradius` prefix and the prefix is not included into tab
 |  client_unknown_type_request_total                 | [$NAME, $IP, $PORT, $CNAME, $CIP]     | counter   |
 |  client_bad_authenticator_request_total            | [$NAME, $IP, $PORT, $CNAME, $CIP]     | counter   |
 
+Besides these metrics RADIUS client also may create optional server status metrics which
+could be enabled via `server_status_metrics_enabled` configuration option. These metrics
+represent active/inactive state of upstream RADIUS servers that RADIUS clients
+send requests to.
+
+If RADIUS server status metrics are enabled following additional metric will be exposed:
+
+| Metric                      | Labels              | Type    |
+|-----------------------------|---------------------|---------|
+| server_status               | [ $IP, $PORT ]      | boolean |
+
+
 ### Labels
 
 Following prometheus labels are used to specify a metric:

--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ Example of full configuration with keys which can use in `eradius`:
             {{127, 0, 0, 3}, 1812, <<"secret">>}
         ]}
     ]},
+    {server_status_metrics_enabled, false},
+    {counter_aggregator, false},
     %% Size of RADIUS receive buffer      
     {recbuf, 8192}
 ]}].
@@ -269,12 +271,15 @@ All pools are configured via:
     %%% ...
 ]}]
 ```
+
 ## Failover Erlang code usage
 In a case when RADIUS proxy (eradius_proxy handler) is not used, a list of RADIUS upstream servers could be passed to the `eradius_client:send_radius_request/3` via options, for example:
 ```erlang
 eradius_client:send_request(Server, Request, [{failover, [{"localhost", 1814, <<"secret">>}]}]).
 ```
 If `failover` option was not passed to the client through the options or RADIUS proxy configuration there should not be any performance impact as RADIUS client will try to a RADIUS request to only one RADIUS server that is defined in `eradius_client:send_request/3` options.
+
+For each secondary RADIUS server server status metrics could be enabled via boolean `server_status_metrics_enabled` configuration option.
 
 # Eradius counter aggregator
 The `eradius_counter_aggregator` would go over all nodes in an Erlang cluster and aggregate the counter values from all nodes.  

--- a/src/eradius.app.src
+++ b/src/eradius.app.src
@@ -13,6 +13,7 @@
       {resend_timeout, 30000},
       {logging, false},
       {counter_aggregator, false},
+      {server_status_metrics_enabled, false},
       {logfile, "./radius.log"},
       {recbuf, 8192}
    ]},


### PR DESCRIPTION
This commits adds new configuration option - `server_status_metrics_enabled` to
enable new RADIUS server status metrics.
    
This was done to avoid situation when eradius is used without prometheus library
so creation/usage of this metric will not be crashed at startup of eradius
application.
    
The default value of the new configuration option is set to `false` to preserve
backward compatibility.
