### PR TITLE
Support optional socket options

### DIFF
--- a/src/eradius_server_sup.erl
+++ b/src/eradius_server_sup.erl
@@ -18,7 +18,11 @@ start_link() ->
 
 start_instance(_ServerAddr = {ServerName, {IP, Port}}) ->
     ?LOG(info, "Starting RADIUS Listener at ~s", [printable_peer(IP, Port)]),
-    supervisor:start_child(?SERVER, [ServerName, IP, Port]).
+    supervisor:start_child(?SERVER, [ServerName, IP, Port]);
+
+start_instance(_ServerAddr = {ServerName, {IP, Port, Opts}}) ->
+    ?LOG(info, "Starting RADIUS Listener at ~s", [printable_peer(IP, Port)]),
+    supervisor:start_child(?SERVER, [ServerName, IP, Port, Opts]).
 
 stop_instance(_ServerAddr = {_ServerName, {IP, Port}}, Pid) ->
     ?LOG(info, "Stopping RADIUS Listener at ~s", [printable_peer(IP, Port)]),


### PR DESCRIPTION
Add the possibility to create a server passing extra options like netns and vrf.

Example:

```erlang
%% vim: ft=erlang
[{eradius, [
  {tables, [dictionary]},
  {session_nodes, local},
  {radius_callback, fake_radius},
  {root, [
      {{"root", []}, [{"10.11.11.1", "testing123"}]}
  ]},
  {servers, [
      {root, {"10.11.11.2", [1812, 1813], [{netns, "/var/run/netns/myns"}]}}
  ]}
]}].
```