### PR TITLE
Bugfix/ipv6 handling

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,0 +1,20 @@
+## `eradius` version
+[Put release version here ...](https://github.com/travelping/eradius/releases/tag/Release version here ...)
+
+## `Erlang/OTP` version
+Put the `Erlang/OTP` version ...
+
+## Description
+* **Motivation**
+(Optional)Describe motivation ...
+* **Proposal**
+(Optional)Describe proposal of the solution ...
+
+## Current behavior
+Describe current behavior ...
+
+## Expected behavior
+Describe expected behavior ...
+
+## Config
+(Optional)Put configuration ...

--- a/applications/eradius_prometheus_collector/rebar.config
+++ b/applications/eradius_prometheus_collector/rebar.config
@@ -1,3 +1,3 @@
 {deps, [
-  {prometheus, "4.6.0"}
+  {prometheus, {git, "https://github.com/deadtrickster/prometheus.erl.git", {branch, "master"}}}
 ]}.

--- a/src/eradius_client.erl
+++ b/src/eradius_client.erl
@@ -76,14 +76,14 @@ send_request({Host, Port, Secret}, Request, Options)
             send_request({IP, Port, Secret}, Request, Options);
         _Err ->
           case inet:gethostbyname(Host, inet6) of
-            {ok, #hostent{h_addrtype = inet6, h_addr_list = [IP]}} ->
-                send_request({IP, Port, Secret}, Request, Options);
-            {ok, #hostent{h_addrtype = inet6, h_addr_list = [_ | _] = IPs}} ->
-                Index = rand:uniform(length(IPs)),
-                IP = lists:nth(Index, IPs),
-                send_request({IP, Port, Secret}, Request, Options);
-            _Err ->
-              error(badarg)
+              {ok, #hostent{h_addrtype = inet6, h_addr_list = [IP]}} ->
+                  send_request({IP, Port, Secret}, Request, Options);
+              {ok, #hostent{h_addrtype = inet6, h_addr_list = [_ | _] = IPs}} ->
+                  Index = rand:uniform(length(IPs)),
+                  IP = lists:nth(Index, IPs),
+                  send_request({IP, Port, Secret}, Request, Options);
+              _Err ->
+                  error(badarg)
           end
     end;
 send_request({IP, Port, Secret}, Request, Options) when ?GOOD_CMD(Request) andalso is_tuple(IP) ->
@@ -327,11 +327,11 @@ init([]) ->
 
 %% @private
 inet_family_based_on_peer(_PeerSocket = {{_, _, _, _}, _port}) ->
-  [inet];
+    [inet];
 inet_family_based_on_peer(_PeerSocket = {{_, _, _, _, _, _, _, _}, _port}) ->
-  [inet6];
+    [inet6];
 inet_family_based_on_peer(_PeerSocket) ->
-  [].
+    [].
 
 %% @private
 handle_call({wanna_send, Peer = {_PeerName, PeerSocket}, _MetricsInfo}, _From, State) ->

--- a/src/eradius_client_socket.erl
+++ b/src/eradius_client_socket.erl
@@ -2,22 +2,23 @@
 
 -behaviour(gen_server).
 
--export([start/3]).
+-export([start/4]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
 
 -record(state, {client, socket, pending, mode, counter}).
 
-start(SocketIP, Client, PortIdx) ->
-    gen_server:start_link(?MODULE, [SocketIP, Client, PortIdx], []).
+start(SocketIP, Client, PortIdx, Options) ->
+    gen_server:start_link(?MODULE, [SocketIP, Client, PortIdx, Options], []).
 
-init([SocketIP, Client, PortIdx]) ->
+init([SocketIP, Client, PortIdx, Options]) ->
     Client ! {PortIdx, self()},
-    case SocketIP of
+    ExtraOptions =
+      case SocketIP of
         undefined ->
-            ExtraOptions = [];
+          Options;
         SocketIP when is_tuple(SocketIP) ->
-            ExtraOptions = [{ip, SocketIP}]
-    end,
+          [{ip, SocketIP} | Options]
+      end,
     RecBuf = application:get_env(eradius, recbuf, 8192),
     {ok, Socket} = gen_udp:open(0, [{active, once}, binary , {recbuf, RecBuf} | ExtraOptions]),
     {ok, #state{client = Client, socket = Socket, pending = maps:new(), mode = active, counter = 0}}.

--- a/src/eradius_client_socket.erl
+++ b/src/eradius_client_socket.erl
@@ -13,12 +13,12 @@ start(SocketIP, Client, PortIdx, Options) ->
 init([SocketIP, Client, PortIdx, Options]) ->
     Client ! {PortIdx, self()},
     ExtraOptions =
-      case SocketIP of
-        undefined ->
-          Options;
-        SocketIP when is_tuple(SocketIP) ->
-          [{ip, SocketIP} | Options]
-      end,
+        case SocketIP of
+            undefined ->
+                Options;
+            SocketIP when is_tuple(SocketIP) ->
+                [{ip, SocketIP} | Options]
+        end,
     RecBuf = application:get_env(eradius, recbuf, 8192),
     {ok, Socket} = gen_udp:open(0, [{active, once}, binary , {recbuf, RecBuf} | ExtraOptions]),
     {ok, #state{client = Client, socket = Socket, pending = maps:new(), mode = active, counter = 0}}.


### PR DESCRIPTION
Changes:
- Fixing IPv6 parse function - IPv6 address is a tuple of 8 hextets (not 6)
- Adding AAAA class host-name resolution (:inet6)
- Adding switch between :inet and :inet6 address families for UDP client's socket opening based on the server's address