### PR TITLE
Use native time unit for prometheus histograms

### DIFF
--- a/src/eradius_client.erl
+++ b/src/eradius_client.erl
@@ -71,7 +71,7 @@ send_request({Host, Port, Secret}, Request, Options)
     IP = get_ip(Host),
     send_request({IP, Port, Secret}, Request, Options);
 send_request({IP, Port, Secret}, Request, Options) when ?GOOD_CMD(Request) andalso is_tuple(IP) ->
-    TS1 = eradius_lib:timestamp(milli_seconds),
+    TS1 = erlang:monotonic_time(),
     ServerName = proplists:get_value(server_name, Options, undefined),
     MetricsInfo = make_metrics_info(Options, {IP, Port}),
     Retries = proplists:get_value(retries, Options, ?DEFAULT_RETRIES),
@@ -122,7 +122,7 @@ send_remote_request(Node, NAS, Request) ->
 %   The request will not be sent again if the remote node is unreachable.
 -spec send_remote_request(node(), nas_address(), #radius_request{}, options()) -> {ok, binary()} | {error, 'timeout' | 'node_down' | 'socket_down'}.
 send_remote_request(Node, {IP, Port, Secret}, Request, Options) when ?GOOD_CMD(Request) ->
-    TS1 = eradius_lib:timestamp(milli_seconds),
+    TS1 = erlang:monotonic_time(),
     ServerName = proplists:get_value(server_name, Options, undefined),
     MetricsInfo = make_metrics_info(Options, {IP, Port}),
     update_client_requests(MetricsInfo),
@@ -160,7 +160,7 @@ restore_upstream_server({ServerIP, Port, Retries, InitialRetries}) ->
     ets:insert(?MODULE, {{ServerIP, Port}, Retries, InitialRetries}).
 
 proceed_response(Request, {ok, Response, Secret, Authenticator}, _Peer = {_ServerName, {ServerIP, Port}}, TS1, MetricsInfo, Options) ->
-    update_client_request(Request#radius_request.cmd, MetricsInfo, eradius_lib:timestamp(milli_seconds) - TS1, Request),
+    update_client_request(Request#radius_request.cmd, MetricsInfo, erlang:monotonic_time() - TS1, Request),
     update_client_responses(MetricsInfo),
     case eradius_lib:decode_request(Response, Secret, Authenticator) of
         {bad_pdu, "Message-Authenticator Attribute is invalid" = Reason} ->
@@ -187,7 +187,7 @@ proceed_response(Request, {ok, Response, Secret, Authenticator}, _Peer = {_Serve
 
 proceed_response(Request, Response, {_ServerName, {ServerIP, Port}}, TS1, MetricsInfo, Options) ->
     update_client_responses(MetricsInfo),
-    update_client_request(Request#radius_request.cmd, MetricsInfo, eradius_lib:timestamp(milli_seconds) - TS1, Request),
+    update_client_request(Request#radius_request.cmd, MetricsInfo, erlang:monotonic_time() - TS1, Request),
     maybe_failover(Request, Response, {ServerIP, Port}, Options).
 
 maybe_failover(Request, Response, {ServerIP, Port}, Options) ->
@@ -241,7 +241,8 @@ send_request_loop(Socket, ReqId, Peer, Request, Retries, Timeout, MetricsInfo) -
     send_request_loop(Socket, SMon, Peer, ReqId, Authenticator, EncRequest, Timeout, Retries, MetricsInfo, Request#radius_request.secret, Request).
 
 send_request_loop(_Socket, SMon, _Peer, _ReqId, _Authenticator, _EncRequest, Timeout, 0, MetricsInfo, _Secret, Request) ->
-    update_client_request(timeout, MetricsInfo, Timeout, Request),
+    TS = erlang:convert_time_unit(Timeout, millisecond, native),
+    update_client_request(timeout, MetricsInfo, TS, Request),
     erlang:demonitor(SMon, [flush]),
     {error, timeout};
 send_request_loop(Socket, SMon, Peer = {_ServerName, {IP, Port}}, ReqId, Authenticator, EncRequest, Timeout, RetryN, MetricsInfo, Secret, Request) ->
@@ -257,7 +258,8 @@ send_request_loop(Socket, SMon, Peer = {_ServerName, {IP, Port}}, ReqId, Authent
             {error, Error}
     after
         Timeout ->
-            update_client_request(retransmission, MetricsInfo, Timeout, Request),
+            TS = erlang:convert_time_unit(Timeout, millisecond, native),
+            update_client_request(retransmission, MetricsInfo, TS, Request),
             send_request_loop(Socket, SMon, Peer, ReqId, Authenticator, EncRequest, Timeout, RetryN - 1, MetricsInfo, Secret, Request)
     end.
 

--- a/src/eradius_counter.erl
+++ b/src/eradius_counter.erl
@@ -111,6 +111,7 @@ observe(Name, {{ClientName, ClientIP, _}, {ServerName, ServerIP, ServerPort}} = 
             catch _:_ ->
                     Buckets = application:get_env(eradius, histogram_buckets, [10, 30, 50, 75, 100, 1000, 2000]),
                     prometheus_histogram:declare([{name, Name}, {labels, [server_ip, server_port, server_name, client_name, client_ip]},
+                                                  {duration_unit, milliseconds},
                                                   {buckets, Buckets}, {help, Help}]),
                     observe(Name, MetricsInfo, Value, Help)
             end;
@@ -125,6 +126,7 @@ observe(Name, #nas_prop{server_ip = ServerIP, server_port = ServerPort, nas_ip =
             catch _:_ ->
                     Buckets = application:get_env(eradius, histogram_buckets, [10, 30, 50, 75, 100, 1000, 2000]),
                     prometheus_histogram:declare([{name, Name}, {labels, [server_ip, server_port, server_name, nas_ip, nas_id]},
+                                                  {duration_unit, milliseconds},
                                                   {buckets, Buckets}, {help, Help}]),
                     observe(Name, Nas, Value, ServerName, Help)
             end;

--- a/src/eradius_server.erl
+++ b/src/eradius_server.erl
@@ -126,7 +126,7 @@ init({ServerName, IP, Port, Opts}) ->
 %% @private
 handle_info(ReqUDP = {udp, Socket, FromIP, FromPortNo, Packet},
             State  = #state{name = ServerName, transacts = Transacts, ip = _IP, port = _Port}) ->
-    TS1 = eradius_lib:timestamp(milli_seconds),
+    TS1 = erlang:monotonic_time(),
     case lookup_nas(State, FromIP, Packet) of
         {ok, ReqID, Handler, NasProp} ->
             #nas_prop{server_ip = ServerIP, server_port = Port} = NasProp,
@@ -220,7 +220,7 @@ do_radius(ServerPid, ServerName, ReqKey, Handler = {HandlerMod, _}, NasProp, {ud
         {reply, EncReply, {ReqCmd, RespCmd}, Request} ->
             ?LOG(debug, "~s From: ~s INF: Sending response for request ~p",
                         [printable_peer(ServerIP, Port), printable_peer(FromIP, FromPort), ReqKey]),
-            TS2 = eradius_lib:timestamp(milli_seconds),
+            TS2 = erlang:monotonic_time(),
             inc_counter({ReqCmd, RespCmd}, ServerName, NasProp, TS2 - TS1, Request),
             gen_udp:send(Socket, FromIP, FromPort, EncReply),
             case application:get_env(eradius, resend_timeout, 2000) of


### PR DESCRIPTION
Previously milliseconds values were used which leads to wrong
behaviour of prometheus histograms as it expects to get observations
in native time units