### PR TITLE
Resolve a failover RADIUS server hostname if need

### DIFF
--- a/src/eradius_client.erl
+++ b/src/eradius_client.erl
@@ -664,6 +664,14 @@ find_suitable_peer(undefined) ->
     [];
 find_suitable_peer([]) ->
     [];
+find_suitable_peer([{Host, Port, Secret} | Pool]) when is_list(Host) ->
+    try
+	IP = get_ip(Host),
+	find_suitable_peer([{IP, Port, Secret} | Pool])
+    catch _:_ ->
+	% can't resolve ip by some reasons, just ignore it
+	find_suitable_peer(Pool)
+    end;
 find_suitable_peer([{IP, Port, Secret} | Pool]) ->
     case ets:lookup(?MODULE, {IP, Port}) of
         [] ->

--- a/test/eradius_test_handler.erl
+++ b/test/eradius_test_handler.erl
@@ -20,7 +20,7 @@ start() ->
     application:set_env(eradius, unreachable_timeout, 2),
     application:set_env(eradius, servers_pool, [{test_pool, [{localhost(tuple), 1812, "secret"},
                                                              % fake upstream server for fail-over
-                                                             {localhost(tuple), 1820, "secret"}]}]),
+                                                             {localhost(string), 1820, "secret"}]}]),
     application:ensure_all_started(eradius),
     eradius:modules_ready([?MODULE]).
 


### PR DESCRIPTION
RADIUS client API allows to pass list of failover servers. Active
failover servers are stored within internal ets table as list of
IPs/ports. So if a request will fail for a primary RADIUS server -
eradius will try to find active failover server based on passed
list and data from the ets table.

The issue is that failover servers could be passed to the RADIUS
client as list of Hosts/Ports instead of IPs/Ports. This commit
adds resolving of given failover servers hostnames so if list
of failover RADIUS servers contains hostnames eradius client still
could find an active server.