### PR TITLE
Update and harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/hex.yaml
+++ b/.github/workflows/hex.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: erlang:23.2.5.0-alpine
     steps:

--- a/.github/workflows/hex.yaml
+++ b/.github/workflows/hex.yaml
@@ -9,7 +9,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     container:
-      image: erlang:23.2.5.0-alpine
+      image: erlang:27-alpine
     steps:
     - name: Prepare
       run: |

--- a/.github/workflows/hex.yaml
+++ b/.github/workflows/hex.yaml
@@ -17,7 +17,7 @@ jobs:
            apk --no-cache upgrade
            apk --no-cache add gcc git libc-dev libc-utils libgcc linux-headers make bash \
                               musl-dev musl-utils ncurses-dev pcre2 pkgconf scanelf wget zlib
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: work around for permission issue
       run: |
            git config --global --add safe.directory /__w/eradius/eradius

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: [22, 23, 24, 25]
+        otp: [22, 23, 24, 25, 26, 27, 28]
     container:
       image: erlang:${{ matrix.otp }}-alpine
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       image: erlang:${{ matrix.otp }}-alpine
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Build
       run: rebar3 compile
     - name: Run tests
@@ -26,7 +26,7 @@ jobs:
     if: always()
     steps:
     - name: Slack notification
-      uses: 8398a7/action-slack@v3
+      uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
       with:
         author_name: "GitHub Actions"
         username: ${{ github.event.repository.name }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
 
   slack:
     needs: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: always()
     steps:
     - name: Slack notification


### PR DESCRIPTION
## Summary

Modernise all GitHub Actions workflow files: pin actions to commit SHAs for supply-chain security, update runner images, and expand the OTP test matrix.

## Changes

### Actions — version updates + SHA pinning

| File | Action | Old | New | Commit SHA |
|------|--------|-----|-----|------------|
| `main.yml`, `hex.yaml` | `actions/checkout` | `v3` | `v6.0.2` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `main.yml` | `8398a7/action-slack` | `v3` | `v3.19.0` | `77eaa4f1c608a7d68b38af4e3f739dcd8cba273e` |

All `uses:` references are now pinned to their exact commit SHA with the version tag as a comment. This prevents a compromised or force-pushed tag from silently swapping the action code.

### Runner images

| File | Job | Old | New |
|------|-----|-----|-----|
| `main.yml` | `slack` | `ubuntu-20.04` (EOL) | `ubuntu-latest` |
| `hex.yaml` | `publish` | `ubuntu-20.04` (EOL) | `ubuntu-latest` |

### Erlang/OTP container versions

| File | Old | New | Notes |
|------|-----|-----|-------|
| `main.yml` matrix | `[22, 23, 24, 25]` | `[22, 23, 24, 25, 26, 27, 28]` | Added OTP 26–28; OTP 29 is still RC |
| `hex.yaml` container | `erlang:23.2.5.0-alpine` | `erlang:27-alpine` | Updated to latest proven-stable series |

Current latest patch per major (as of 2026-04):
`22.3.4.27` · `23.3.4.20` · `24.3.4.16` · `25.3.2.11` · `26.2.5` · `27.3.4` · `28.4.1`

> OTP 27 is used for the hex publish workflow as the latest well-established series. OTP 28 can be promoted once it has broader ecosystem adoption.

## Test plan

- [ ] CI workflow triggers on push and all 7 OTP matrix jobs pass
- [ ] Hex publish workflow triggers on a tag push and completes successfully
- [ ] Slack notification is delivered after CI completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)